### PR TITLE
✨ [Feat] 수취인 엔티티 추가 및 연관관계 설정

### DIFF
--- a/src/main/java/com/example/scoi/domain/transfer/entity/Recipient.java
+++ b/src/main/java/com/example/scoi/domain/transfer/entity/Recipient.java
@@ -1,0 +1,47 @@
+package com.example.scoi.domain.transfer.entity;
+
+import com.example.scoi.domain.member.entity.Member;
+import com.example.scoi.domain.member.enums.MemberType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "recipient")
+public class Recipient {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "wallet_address", nullable = false)
+    private String walletAddress; // 출금 주소
+
+    // 수취인 기본 정보
+    @Column(name = "recipient_en_name", length = 50, nullable = false)
+    private String recipientEnName;
+    @Column(name = "recipient_ko_name", length = 5, nullable = false)
+    private String recipientKoName;
+
+    @Column(name = "recipient_type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private MemberType recipientType;
+
+    // 수취인 법인 영문명 (개인일 경우 null)
+    @Column(name = "recipient_corp_en_name", length = 50, nullable = true)
+    private String recipientCorpEnName;
+    // 수취인 법인 국문명 (개인일 경우 null)
+    @Column(name = "recipient_corp_ko_name", length = 50, nullable = true)
+    private String recipientCorpKoName;
+
+    @Column(name = "is_favorite", nullable = false)
+    @Builder.Default
+    private Boolean isFavorite = false;
+
+    // 연관 관계
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id", nullable = false)
+    private Member member;
+}

--- a/src/main/java/com/example/scoi/domain/transfer/entity/TradeHistory.java
+++ b/src/main/java/com/example/scoi/domain/transfer/entity/TradeHistory.java
@@ -24,16 +24,6 @@ public class TradeHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "target_member_id", nullable = false)
-    private Long targetMemberId;
-
-    @Column(name = "target_wallet", nullable = false)
-    private String targetWallet;
-
-    @Column(name = "is_favorite", nullable = false)
-    @Builder.Default
-    private Boolean isFavorite = false;
-
     @Column(name = "exchange_type", nullable = false)
     @Enumerated(EnumType.STRING)
     private ExchangeType exchangeType;
@@ -58,6 +48,10 @@ public class TradeHistory {
 
     // 연관관계
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "member_id")
+    @JoinColumn(name = "member_id", nullable = false)
     private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "recipient_id", nullable = false)
+    private Recipient recipient;
 }

--- a/src/main/java/com/example/scoi/domain/transfer/repository/RecipientRepository.java
+++ b/src/main/java/com/example/scoi/domain/transfer/repository/RecipientRepository.java
@@ -1,0 +1,7 @@
+package com.example.scoi.domain.transfer.repository;
+
+import com.example.scoi.domain.transfer.entity.Recipient;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecipientRepository extends JpaRepository<Recipient, Long> {
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #10 

## 📌 개요
- 즐겨찾기 등록 시 TradeHistory 내부 필수 속성을 채우지 못하는 문제가 발생
- TradeHistory 내부 수취인 정보를 Recipient 엔티티로 따로 빼서 저장했습니다.

## 🔁 변경 사항

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
TradeHistory 엔티티에는 수취인 정보 없이 recipient 테이블에 1:N으로 연결했습니다.
## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [ ] 변경 내용에 대한 테스트를 진행했어요.
- [ ] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [ ] 불필요한 코드는 삭제했어요.
