### PR TITLE
🐛 [Bug] @Configuration 어노테이션 제거

### DIFF
--- a/src/main/java/com/example/scoi/global/config/CoolSmsConfig.java
+++ b/src/main/java/com/example/scoi/global/config/CoolSmsConfig.java
@@ -4,7 +4,7 @@ import feign.RequestInterceptor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -14,7 +14,6 @@ import java.time.format.DateTimeFormatter;
 import java.util.UUID;
 
 @Slf4j
-@Configuration
 public class CoolSmsConfig {
 
     @Value("${coolsms.api-key}")


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #47 

## 📌 개요
- 47번 이슈를 해결합니다 (coolSmsRequestInterceptor Bean이 모든 Feign 클라이언트 (업비트, 빗썸)에 CoolSMS용 Authorization 헤더가 붙어서 요청 처리를 못하는 버그)

## 🔁 변경 사항
- 어노테이션 제거

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 업비트, 빗썸 등에서 요청이 정상적으로 작동하는지 확인 필요합니다

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
