### PR TITLE
✨ [Feat] 거래내역 전체 조회 입출금/충전, 상세조회 추가

### DIFF
--- a/src/main/java/com/example/scoi/domain/myWallet/client/MyWalletExchangeClient.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/client/MyWalletExchangeClient.java
@@ -1,0 +1,79 @@
+package com.example.scoi.domain.myWallet.client;
+
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * 여러 거래소 어댑터를 한 타입으로 묶기 위한 인터페이스
+ */
+public interface MyWalletExchangeClient {
+
+    /**
+     * 현재 계좌 잔고를 조회합니다. (USDT, USDC)
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @return 통화별 잔고 (balance + locked 합산)
+     */
+    Map<String, BigDecimal> getBalances(String phoneNumber);
+
+    /**
+     * 코인 입금 리스트를 조회합니다. (USDT + USDC)
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @return 입금 거래 내역 리스트
+     */
+    List<MyWalletResDTO.TransactionDTO> getDeposits(String phoneNumber);
+
+    /**
+     * 코인 출금 리스트를 조회합니다. (USDT + USDC)
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @return 출금 거래 내역 리스트
+     */
+    List<MyWalletResDTO.TransactionDTO> getWithdraws(String phoneNumber);
+
+    /**
+     * 주문 리스트를 조회합니다. (KRW-USDT + KRW-USDC 충전 거래 내역)
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @param state       주문 상태 (DONE, WAIT, CANCEL)
+     * @param periodType  조회 기간
+     * @param order       정렬 순서 (desc: 최신순, asc: 과거순)
+     * @param limit       최대 조회 건수
+     * @return 충전 거래 내역 리스트
+     */
+    List<MyWalletResDTO.TopupTransactionDTO> getOrders(
+            String phoneNumber,
+            OrderState state,
+            PeriodType periodType,
+            String order,
+            int limit
+    );
+
+    /**
+     * 개별 입금 내역을 조회합니다.
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @param uuid        입금 UUID
+     * @param currency    통화 코드 (USDT, USDC 등, nullable)
+     * @return 입금 상세 정보
+     */
+    MyWalletResDTO.RemitDetailDTO getDepositDetail(String phoneNumber, String uuid, String currency);
+
+    /**
+     * 개별 출금 내역을 조회합니다.
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @param uuid        출금 UUID
+     * @param currency    통화 코드 (USDT, USDC 등, nullable)
+     * @return 출금 상세 정보
+     */
+    MyWalletResDTO.RemitDetailDTO getWithdrawDetail(String phoneNumber, String uuid, String currency);
+
+    /**
+     * 개별 주문 내역을 조회합니다.
+     * @param phoneNumber 사용자 휴대폰 번호
+     * @param uuid        주문 UUID
+     * @return 주문 상세 정보 (체결 내역 포함)
+     */
+    MyWalletResDTO.TopupDetailDTO getOrderDetail(String phoneNumber, String uuid);
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/client/adapter/MyWalletBithumbClient.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/client/adapter/MyWalletBithumbClient.java
@@ -1,0 +1,257 @@
+package com.example.scoi.domain.myWallet.client.adapter;
+
+import com.example.scoi.domain.myWallet.client.MyWalletExchangeClient;
+import com.example.scoi.domain.myWallet.client.feign.MyWalletBithumbFeignClient;
+import com.example.scoi.domain.myWallet.converter.MyWalletConverter;
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.dto.TopupClientDTO;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+import com.example.scoi.domain.member.exception.MemberException;
+import com.example.scoi.domain.myWallet.exception.MyWalletException;
+import com.example.scoi.domain.myWallet.exception.code.MyWalletErrorCode;
+import com.example.scoi.global.client.dto.BithumbResDTO;
+import com.example.scoi.global.util.JwtApiUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.security.GeneralSecurityException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MyWalletBithumbClient implements MyWalletExchangeClient {
+
+    private final MyWalletBithumbFeignClient bithumbFeignClient;
+    private final JwtApiUtil jwtApiUtil;
+
+    private static final int MAX_LIMIT = 100;
+    private static final String ORDER_DESC = "desc";
+    private static final List<String> CURRENCIES = List.of("USDT", "USDC");
+    private static final List<String> MARKETS = List.of("KRW-USDT", "KRW-USDC");
+
+    @Override
+    public Map<String, BigDecimal> getBalances(String phoneNumber) {
+        try {
+            log.info("빗썸 계좌 잔고 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, "", null);
+            var accounts = bithumbFeignClient.getAccounts(authorization);
+
+            Map<String, BigDecimal> balances = new HashMap<>();
+            for (var account : accounts) {
+                if (CURRENCIES.contains(account.currency())) {
+                    BigDecimal total = new BigDecimal(account.balance())
+                            .add(new BigDecimal(account.locked()));
+                    balances.put(account.currency(), total);
+                }
+            }
+
+            for (String currency : CURRENCIES) {
+                balances.putIfAbsent(currency, BigDecimal.ZERO);
+            }
+
+            log.info("빗썸 계좌 잔고 조회 완료 - balances: {}", balances);
+            return balances;
+
+        } catch (Exception e) {
+            throw handleException("빗썸 계좌 잔고 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TransactionDTO> getDeposits(String phoneNumber) {
+        try {
+            log.info("빗썸 코인 입금 리스트 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            List<MyWalletResDTO.TransactionDTO> allDeposits = new ArrayList<>();
+
+            for (String currency : CURRENCIES) {
+                String query = "currency=" + currency + "&limit=" + MAX_LIMIT + "&page=1&order_by=" + ORDER_DESC;
+                String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+                List<BithumbResDTO.GetDeposit> deposits = bithumbFeignClient.getDeposits(authorization, currency, MAX_LIMIT, 1, ORDER_DESC);
+
+                log.info("빗썸 {} 입금 조회 완료 - 건수: {}", currency, deposits.size());
+                allDeposits.addAll(deposits.stream()
+                        .map(MyWalletConverter::fromBithumbDeposit)
+                        .toList());
+            }
+
+            log.info("빗썸 코인 입금 리스트 조회 완료 - 총 건수: {}", allDeposits.size());
+            return allDeposits;
+
+        } catch (Exception e) {
+            throw handleException("빗썸 코인 입금 리스트 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TransactionDTO> getWithdraws(String phoneNumber) {
+        try {
+            log.info("빗썸 코인 출금 리스트 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            List<MyWalletResDTO.TransactionDTO> allWithdraws = new ArrayList<>();
+
+            for (String currency : CURRENCIES) {
+                String query = "currency=" + currency + "&limit=" + MAX_LIMIT + "&page=1&order_by=" + ORDER_DESC;
+                String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+                List<BithumbResDTO.GetWithdraw> withdraws = bithumbFeignClient.getWithdraws(authorization, currency, MAX_LIMIT, 1, ORDER_DESC);
+
+                log.info("빗썸 {} 출금 조회 완료 - 건수: {}", currency, withdraws.size());
+                allWithdraws.addAll(withdraws.stream()
+                        .map(MyWalletConverter::fromBithumbWithdraw)
+                        .toList());
+            }
+
+            log.info("빗썸 코인 출금 리스트 조회 완료 - 총 건수: {}", allWithdraws.size());
+            return allWithdraws;
+
+        } catch (Exception e) {
+            throw handleException("빗썸 코인 출금 리스트 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TopupTransactionDTO> getOrders(
+            String phoneNumber, OrderState state, PeriodType periodType, String order, int limit) {
+        try {
+            log.info("빗썸 주문 리스트 조회 시작 - phoneNumber: {}, state: {}, order: {}", phoneNumber, state, order);
+
+            List<MyWalletResDTO.TopupTransactionDTO> allOrders = new ArrayList<>();
+            String stateValue = state.toApiValue();
+
+            for (String market : MARKETS) {
+                String query = "market=" + market + "&state=" + stateValue
+                        + "&limit=" + MAX_LIMIT + "&page=1&order_by=" + order;
+                String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+                List<TopupClientDTO.BithumbOrder> orders = bithumbFeignClient.getOrders(
+                        authorization, market, stateValue, MAX_LIMIT, 1, order);
+
+                log.info("빗썸 {} 주문 조회 완료 - state: {}, 건수: {}", market, stateValue, orders.size());
+                allOrders.addAll(orders.stream()
+                        .map(MyWalletConverter::fromBithumbOrder)
+                        .toList());
+            }
+
+            log.info("빗썸 주문 리스트 조회 완료 - 총 건수: {}", allOrders.size());
+            return allOrders;
+
+        } catch (Exception e) {
+            throw handleException("빗썸 주문 리스트 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public MyWalletResDTO.RemitDetailDTO getDepositDetail(String phoneNumber, String uuid, String currency) {
+        try {
+            log.info("빗썸 개별 입금 조회 시작 - uuid: {}, currency: {}", uuid, currency);
+
+            String query = buildDetailQuery(uuid, currency);
+            String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+            BithumbResDTO.GetDeposit deposit = bithumbFeignClient.getDeposit(authorization, uuid, null, currency);
+
+            log.info("빗썸 개별 입금 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromBithumbDepositDetail(deposit);
+
+        } catch (Exception e) {
+            throw handleException("빗썸 개별 입금 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public MyWalletResDTO.RemitDetailDTO getWithdrawDetail(String phoneNumber, String uuid, String currency) {
+        try {
+            log.info("빗썸 개별 출금 조회 시작 - uuid: {}, currency: {}", uuid, currency);
+
+            String query = buildDetailQuery(uuid, currency);
+            String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+            BithumbResDTO.GetWithdraw withdraw = bithumbFeignClient.getWithdraw(authorization, uuid, null, currency);
+
+            log.info("빗썸 개별 출금 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromBithumbWithdrawDetail(withdraw);
+
+        } catch (Exception e) {
+            throw handleException("빗썸 개별 출금 조회", phoneNumber, e);
+        }
+    }
+
+    /**
+     * 개별 입출금 조회용 query string 생성 (uuid + currency)
+     */
+    private String buildDetailQuery(String uuid, String currency) {
+        StringBuilder query = new StringBuilder("uuid=" + uuid);
+        if (currency != null && !currency.isBlank()) {
+            query.append("&currency=").append(currency);
+        }
+        return query.toString();
+    }
+
+    @Override
+    public MyWalletResDTO.TopupDetailDTO getOrderDetail(String phoneNumber, String uuid) {
+        try {
+            log.info("빗썸 개별 주문 조회 시작 - uuid: {}", uuid);
+
+            String query = "uuid=" + uuid;
+            String authorization = jwtApiUtil.createBithumbJwt(phoneNumber, query, null);
+            BithumbResDTO.GetOrder order = bithumbFeignClient.getOrder(authorization, uuid);
+
+            log.info("빗썸 개별 주문 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromBithumbOrderDetail(order);
+
+        } catch (Exception e) {
+            throw handleException("빗썸 개별 주문 조회", phoneNumber, e);
+        }
+    }
+
+    /**
+     * 공통 예외 처리: Feign 예외를 세분화하여 적절한 MyWalletException으로 변환
+     */
+    private MyWalletException handleException(String operation, String phoneNumber, Exception e) {
+        // 이미 MyWalletException이면 그대로 전달
+        if (e instanceof MyWalletException mwe) {
+            return mwe;
+        }
+        // API 키 미등록
+        if (e instanceof MemberException) {
+            log.error("{} 실패 - API 키 미등록 - phoneNumber: {}", operation, phoneNumber);
+            return new MyWalletException(MyWalletErrorCode.API_KEY_NOT_FOUND);
+        }
+        // JWT 생성 실패
+        if (e instanceof GeneralSecurityException) {
+            log.error("{} 실패 - JWT 생성 실패", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+        }
+        // Feign 401: 권한 부족
+        if (e instanceof feign.FeignException.Unauthorized) {
+            log.error("{} 실패 - API 키 권한 부족", operation, e);
+            return new MyWalletException(MyWalletErrorCode.INSUFFICIENT_API_PERMISSION);
+        }
+        // Feign 429: Rate Limit 초과
+        if (e instanceof feign.FeignException.TooManyRequests) {
+            log.error("{} 실패 - 거래소 API 호출 한도 초과", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_RATE_LIMIT);
+        }
+        // Feign 500+: 거래소 서버 에러
+        if (e instanceof feign.FeignException.InternalServerError
+                || e instanceof feign.FeignException.BadGateway
+                || e instanceof feign.FeignException.ServiceUnavailable) {
+            log.error("{} 실패 - 거래소 서버 에러", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_SERVER_ERROR);
+        }
+        // Feign 504 또는 타임아웃
+        if (e instanceof feign.FeignException.GatewayTimeout
+                || e instanceof feign.RetryableException) {
+            log.error("{} 실패 - 거래소 API 타임아웃", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_TIMEOUT);
+        }
+        // 그 외 에러
+        log.error("{} 실패", operation, e);
+        return new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+    }
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/client/adapter/MyWalletUpbitClient.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/client/adapter/MyWalletUpbitClient.java
@@ -1,0 +1,327 @@
+package com.example.scoi.domain.myWallet.client.adapter;
+
+import com.example.scoi.domain.myWallet.client.MyWalletExchangeClient;
+import com.example.scoi.domain.myWallet.client.feign.MyWalletUpbitFeignClient;
+import com.example.scoi.domain.myWallet.converter.MyWalletConverter;
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.dto.TopupClientDTO;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+import com.example.scoi.domain.member.exception.MemberException;
+import com.example.scoi.domain.myWallet.exception.MyWalletException;
+import com.example.scoi.domain.myWallet.exception.code.MyWalletErrorCode;
+import com.example.scoi.global.client.dto.UpbitResDTO;
+import com.example.scoi.global.util.JwtApiUtil;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.security.GeneralSecurityException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class MyWalletUpbitClient implements MyWalletExchangeClient {
+
+    private final MyWalletUpbitFeignClient upbitFeignClient;
+    private final JwtApiUtil jwtApiUtil;
+
+    private static final int MAX_LIMIT = 100;
+    private static final String ORDER_DESC = "desc";
+    private static final List<String> CURRENCIES = List.of("USDT", "USDC");
+    private static final List<String> MARKETS = List.of("KRW-USDT", "KRW-USDC");
+    private static final int MAX_API_CALLS = 28;
+    private static final int WINDOW_DAYS = 7;
+
+    @Override
+    public Map<String, BigDecimal> getBalances(String phoneNumber) {
+        try {
+            log.info("업비트 계좌 잔고 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, null, null);
+            var accounts = upbitFeignClient.getAccounts(authorization);
+
+            Map<String, BigDecimal> balances = new HashMap<>();
+            for (var account : accounts) {
+                if (CURRENCIES.contains(account.currency())) {
+                    BigDecimal total = new BigDecimal(account.balance())
+                            .add(new BigDecimal(account.locked()));
+                    balances.put(account.currency(), total);
+                }
+            }
+
+            for (String currency : CURRENCIES) {
+                balances.putIfAbsent(currency, BigDecimal.ZERO);
+            }
+
+            log.info("업비트 계좌 잔고 조회 완료 - balances: {}", balances);
+            return balances;
+
+        } catch (Exception e) {
+            throw handleException("업비트 계좌 잔고 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TransactionDTO> getDeposits(String phoneNumber) {
+        try {
+            log.info("업비트 코인 입금 목록 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            List<MyWalletResDTO.TransactionDTO> allDeposits = new ArrayList<>();
+
+            for (String currency : CURRENCIES) {
+                String query = "currency=" + currency + "&limit=" + MAX_LIMIT + "&page=1&order_by=" + ORDER_DESC;
+                String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+                List<UpbitResDTO.GetDeposit> deposits = upbitFeignClient.getDeposits(authorization, currency, MAX_LIMIT, 1, ORDER_DESC);
+
+                log.info("업비트 {} 입금 조회 완료 - 건수: {}", currency, deposits.size());
+                allDeposits.addAll(deposits.stream()
+                        .map(MyWalletConverter::fromUpbitDeposit)
+                        .toList());
+            }
+
+            log.info("업비트 코인 입금 목록 조회 완료 - 총 건수: {}", allDeposits.size());
+            return allDeposits;
+
+        } catch (Exception e) {
+            throw handleException("업비트 코인 입금 목록 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TransactionDTO> getWithdraws(String phoneNumber) {
+        try {
+            log.info("업비트 코인 출금 목록 조회 시작 - phoneNumber: {}", phoneNumber);
+
+            List<MyWalletResDTO.TransactionDTO> allWithdraws = new ArrayList<>();
+
+            for (String currency : CURRENCIES) {
+                String query = "currency=" + currency + "&limit=" + MAX_LIMIT + "&page=1&order_by=" + ORDER_DESC;
+                String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+                List<UpbitResDTO.GetWithdraw> withdraws = upbitFeignClient.getWithdraws(authorization, currency, MAX_LIMIT, 1, ORDER_DESC);
+
+                log.info("업비트 {} 출금 조회 완료 - 건수: {}", currency, withdraws.size());
+                allWithdraws.addAll(withdraws.stream()
+                        .map(MyWalletConverter::fromUpbitWithdraw)
+                        .toList());
+            }
+
+            log.info("업비트 코인 출금 목록 조회 완료 - 총 건수: {}", allWithdraws.size());
+            return allWithdraws;
+
+        } catch (Exception e) {
+            throw handleException("업비트 코인 출금 목록 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public List<MyWalletResDTO.TopupTransactionDTO> getOrders(
+            String phoneNumber, OrderState state, PeriodType periodType, String order, int limit) {
+        try {
+            log.info("업비트 주문 리스트 조회 시작 - phoneNumber: {}, state: {}, order: {}", phoneNumber, state, order);
+
+            if (state == OrderState.WAIT) {
+                return getOpenOrdersForAllMarkets(phoneNumber, order);
+            } else {
+                return getClosedOrdersWithWindowing(phoneNumber, state, periodType, order, limit);
+            }
+
+        } catch (Exception e) {
+            throw handleException("업비트 주문 리스트 조회", phoneNumber, e);
+        }
+    }
+
+    /**
+     * 체결 대기 주문 조회 (state=WAIT)
+     */
+    private List<MyWalletResDTO.TopupTransactionDTO> getOpenOrdersForAllMarkets(
+            String phoneNumber, String order) throws GeneralSecurityException {
+        List<MyWalletResDTO.TopupTransactionDTO> allOrders = new ArrayList<>();
+
+        for (String market : MARKETS) {
+            String query = "market=" + market + "&state=wait&limit=" + MAX_LIMIT + "&order_by=" + order;
+            String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+            List<TopupClientDTO.UpbitOrder> orders = upbitFeignClient.getOpenOrders(
+                    authorization, market, "wait", MAX_LIMIT, order);
+
+            log.info("업비트 {} 대기 주문 조회 완료 - 건수: {}", market, orders.size());
+            allOrders.addAll(orders.stream()
+                    .map(MyWalletConverter::fromUpbitOrder)
+                    .toList());
+        }
+
+        log.info("업비트 대기 주문 조회 완료 - 총 건수: {}", allOrders.size());
+        return allOrders;
+    }
+
+    /**
+     * 종료 주문 조회 (state=DONE 또는 CANCEL)
+     * Lazy Windowing + Early Termination + Rate Limit Guard (최대 28회 API 호출)
+     */
+    private List<MyWalletResDTO.TopupTransactionDTO> getClosedOrdersWithWindowing(
+            String phoneNumber, OrderState state, PeriodType periodType,
+            String order, int limit) throws GeneralSecurityException {
+
+        List<MyWalletResDTO.TopupTransactionDTO> allOrders = new ArrayList<>();
+        String stateValue = state.toApiValue();
+        int apiCallCount = 0;
+
+        LocalDate periodStart = periodType.getStartDate();
+        LocalDateTime windowEnd = LocalDateTime.now();
+        LocalDateTime periodStartTime = periodStart.atStartOfDay();
+
+        log.info("업비트 종료 주문 윈도우 조회 시작 - state: {}, period: {} ~ now", stateValue, periodStart);
+
+        while (windowEnd.isAfter(periodStartTime) && apiCallCount < MAX_API_CALLS) {
+            LocalDateTime windowStart = windowEnd.minusDays(WINDOW_DAYS);
+            if (windowStart.isBefore(periodStartTime)) {
+                windowStart = periodStartTime;
+            }
+
+            // 밀리초 타임스탬프 사용 (URL 인코딩 불일치 방지)
+            String startTimeStr = String.valueOf(
+                    windowStart.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli());
+            String endTimeStr = String.valueOf(
+                    windowEnd.atZone(java.time.ZoneId.systemDefault()).toInstant().toEpochMilli());
+
+            for (String market : MARKETS) {
+                if (apiCallCount >= MAX_API_CALLS) {
+                    log.warn("업비트 API 호출 횟수 한도({}) 도달 - 조회 중단", MAX_API_CALLS);
+                    break;
+                }
+
+                String query = "market=" + market + "&state=" + stateValue
+                        + "&limit=" + MAX_LIMIT + "&order_by=" + order
+                        + "&start_time=" + startTimeStr + "&end_time=" + endTimeStr;
+                String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+                List<TopupClientDTO.UpbitOrder> orders = upbitFeignClient.getClosedOrders(
+                        authorization, market, stateValue, MAX_LIMIT, order, startTimeStr, endTimeStr);
+                apiCallCount++;
+
+                log.info("업비트 {} 종료 주문 조회 - window: {} ~ {}, state: {}, 건수: {}, apiCalls: {}",
+                        market, startTimeStr, endTimeStr, stateValue, orders.size(), apiCallCount);
+
+                allOrders.addAll(orders.stream()
+                        .map(MyWalletConverter::fromUpbitOrder)
+                        .toList());
+            }
+
+            if (allOrders.size() >= limit) {
+                log.info("업비트 종료 주문 조회 - limit({}) 도달로 조기 종료", limit);
+                break;
+            }
+
+            windowEnd = windowStart;
+        }
+
+        log.info("업비트 종료 주문 조회 완료 - 총 건수: {}, 총 API 호출: {}", allOrders.size(), apiCallCount);
+        return allOrders;
+    }
+
+    @Override
+    public MyWalletResDTO.RemitDetailDTO getDepositDetail(String phoneNumber, String uuid, String currency) {
+        try {
+            log.info("업비트 개별 입금 조회 시작 - uuid: {}, currency: {}", uuid, currency);
+
+            String query = buildDetailQuery(uuid, currency);
+            String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+            var deposit = upbitFeignClient.getDeposit(authorization, uuid, null, currency);
+
+            log.info("업비트 개별 입금 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromUpbitDepositDetail(deposit);
+
+        } catch (Exception e) {
+            throw handleException("업비트 개별 입금 조회", phoneNumber, e);
+        }
+    }
+
+    @Override
+    public MyWalletResDTO.RemitDetailDTO getWithdrawDetail(String phoneNumber, String uuid, String currency) {
+        try {
+            log.info("업비트 개별 출금 조회 시작 - uuid: {}, currency: {}", uuid, currency);
+
+            String query = buildDetailQuery(uuid, currency);
+            String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+            var withdraw = upbitFeignClient.getWithdraw(authorization, uuid, null, currency);
+
+            log.info("업비트 개별 출금 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromUpbitWithdrawDetail(withdraw);
+
+        } catch (Exception e) {
+            throw handleException("업비트 개별 출금 조회", phoneNumber, e);
+        }
+    }
+
+    /**
+     * 개별 입출금 조회용 query string 생성 (uuid + currency)
+     */
+    private String buildDetailQuery(String uuid, String currency) {
+        StringBuilder query = new StringBuilder("uuid=" + uuid);
+        if (currency != null && !currency.isBlank()) {
+            query.append("&currency=").append(currency);
+        }
+        return query.toString();
+    }
+
+    @Override
+    public MyWalletResDTO.TopupDetailDTO getOrderDetail(String phoneNumber, String uuid) {
+        try {
+            log.info("업비트 개별 주문 조회 시작 - uuid: {}", uuid);
+
+            String query = "uuid=" + uuid;
+            String authorization = jwtApiUtil.createUpBitJwt(phoneNumber, query, null);
+            var order = upbitFeignClient.getOrder(authorization, uuid);
+
+            log.info("업비트 개별 주문 조회 완료 - uuid: {}", uuid);
+            return MyWalletConverter.fromUpbitOrderDetail(order);
+
+        } catch (Exception e) {
+            throw handleException("업비트 개별 주문 조회", phoneNumber, e);
+        }
+    }
+
+    /**
+     * 공통 예외 처리: Feign 예외를 세분화하여 적절한 MyWalletException으로 변환
+     */
+    private MyWalletException handleException(String operation, String phoneNumber, Exception e) {
+        if (e instanceof MyWalletException mwe) {
+            return mwe;
+        }
+        if (e instanceof MemberException) {
+            log.error("{} 실패 - API 키 미등록 - phoneNumber: {}", operation, phoneNumber);
+            return new MyWalletException(MyWalletErrorCode.API_KEY_NOT_FOUND);
+        }
+        if (e instanceof GeneralSecurityException) {
+            log.error("{} 실패 - JWT 생성 실패", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+        }
+        if (e instanceof feign.FeignException.Unauthorized) {
+            log.error("{} 실패 - API 키 권한 부족", operation, e);
+            return new MyWalletException(MyWalletErrorCode.INSUFFICIENT_API_PERMISSION);
+        }
+        if (e instanceof feign.FeignException.TooManyRequests) {
+            log.error("{} 실패 - 거래소 API 호출 한도 초과", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_RATE_LIMIT);
+        }
+        if (e instanceof feign.FeignException.InternalServerError
+                || e instanceof feign.FeignException.BadGateway
+                || e instanceof feign.FeignException.ServiceUnavailable) {
+            log.error("{} 실패 - 거래소 서버 에러", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_SERVER_ERROR);
+        }
+        if (e instanceof feign.FeignException.GatewayTimeout
+                || e instanceof feign.RetryableException) {
+            log.error("{} 실패 - 거래소 API 타임아웃", operation, e);
+            return new MyWalletException(MyWalletErrorCode.EXCHANGE_TIMEOUT);
+        }
+        log.error("{} 실패", operation, e);
+        return new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+    }
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/client/feign/MyWalletBithumbFeignClient.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/client/feign/MyWalletBithumbFeignClient.java
@@ -1,0 +1,81 @@
+package com.example.scoi.domain.myWallet.client.feign;
+
+import com.example.scoi.domain.myWallet.dto.BalanceClientDTO;
+import com.example.scoi.domain.myWallet.dto.TopupClientDTO;
+import com.example.scoi.global.client.dto.BithumbResDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@FeignClient(
+    name = "myWalletBithumbFeignClient",
+    url = "https://api.bithumb.com",
+    configuration = com.example.scoi.global.config.feign.BithumbFeignConfig.class
+)
+public interface MyWalletBithumbFeignClient {
+
+    // 코인 입금 리스트 조회
+    @GetMapping("/v1/deposits")
+    List<BithumbResDTO.GetDeposit> getDeposits(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "currency", required = false) String currency,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 코인 출금 리스트 조회
+    @GetMapping("/v1/withdraws")
+    List<BithumbResDTO.GetWithdraw> getWithdraws(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "currency", required = false) String currency,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 전체 계좌 조회 (잔고)
+    @GetMapping("/v1/accounts")
+    List<BalanceClientDTO.AccountInfo> getAccounts(
+            @RequestHeader("Authorization") String authorization
+    );
+
+    // 주문 리스트 조회 (충전 거래 내역)
+    @GetMapping("/v1/orders")
+    List<TopupClientDTO.BithumbOrder> getOrders(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "market", required = false) String market,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 개별 입금 조회
+    @GetMapping("/v1/deposit")
+    BithumbResDTO.GetDeposit getDeposit(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid", required = false) String uuid,
+            @RequestParam(value = "txid", required = false) String txid,
+            @RequestParam(value = "currency", required = false) String currency
+    );
+
+    // 개별 출금 조회
+    @GetMapping("/v1/withdraw")
+    BithumbResDTO.GetWithdraw getWithdraw(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid", required = false) String uuid,
+            @RequestParam(value = "txid", required = false) String txid,
+            @RequestParam(value = "currency", required = false) String currency
+    );
+
+    // 개별 주문 조회
+    @GetMapping("/v1/order")
+    BithumbResDTO.GetOrder getOrder(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid") String uuid
+    );
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/client/feign/MyWalletUpbitFeignClient.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/client/feign/MyWalletUpbitFeignClient.java
@@ -1,0 +1,92 @@
+package com.example.scoi.domain.myWallet.client.feign;
+
+import com.example.scoi.domain.myWallet.dto.BalanceClientDTO;
+import com.example.scoi.domain.myWallet.dto.TopupClientDTO;
+import com.example.scoi.global.client.dto.UpbitResDTO;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.util.List;
+
+@FeignClient(
+    name = "myWalletUpbitFeignClient",
+    url = "https://api.upbit.com",
+    configuration = com.example.scoi.global.config.feign.UpbitFeignConfig.class
+)
+public interface MyWalletUpbitFeignClient {
+
+    // 입금 목록 조회
+    @GetMapping("/v1/deposits")
+    List<UpbitResDTO.GetDeposit> getDeposits(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "currency", required = false) String currency,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 출금 목록 조회
+    @GetMapping("/v1/withdraws")
+    List<UpbitResDTO.GetWithdraw> getWithdraws(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "currency", required = false) String currency,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "page", required = false) Integer page,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 전체 계좌 조회 (잔고)
+    @GetMapping("/v1/accounts")
+    List<BalanceClientDTO.AccountInfo> getAccounts(
+            @RequestHeader("Authorization") String authorization
+    );
+
+    // 종료 주문 목록 조회 (완료/취소)
+    @GetMapping("/v1/orders/closed")
+    List<TopupClientDTO.UpbitOrder> getClosedOrders(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "market", required = false) String market,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "order_by", required = false) String orderBy,
+            @RequestParam(value = "start_time", required = false) String startTime,
+            @RequestParam(value = "end_time", required = false) String endTime
+    );
+
+    // 체결 대기 주문 목록 조회 (대기)
+    @GetMapping("/v1/orders/open")
+    List<TopupClientDTO.UpbitOrder> getOpenOrders(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "market", required = false) String market,
+            @RequestParam(value = "state", required = false) String state,
+            @RequestParam(value = "limit", required = false) Integer limit,
+            @RequestParam(value = "order_by", required = false) String orderBy
+    );
+
+    // 개별 입금 조회
+    @GetMapping("/v1/deposit")
+    UpbitResDTO.GetDeposit getDeposit(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid", required = false) String uuid,
+            @RequestParam(value = "txid", required = false) String txid,
+            @RequestParam(value = "currency", required = false) String currency
+    );
+
+    // 개별 출금 조회
+    @GetMapping("/v1/withdraw")
+    UpbitResDTO.GetWithdraw getWithdraw(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid", required = false) String uuid,
+            @RequestParam(value = "txid", required = false) String txid,
+            @RequestParam(value = "currency", required = false) String currency
+    );
+
+    // 개별 주문 조회
+    @GetMapping("/v1/order")
+    UpbitResDTO.GetOrder getOrder(
+            @RequestHeader("Authorization") String authorization,
+            @RequestParam(value = "uuid") String uuid
+    );
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/controller/MyWalletController.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/controller/MyWalletController.java
@@ -1,9 +1,119 @@
 package com.example.scoi.domain.myWallet.controller;
 
+import com.example.scoi.domain.member.enums.ExchangeType;
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.enums.DetailCategory;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+import com.example.scoi.domain.myWallet.enums.RemitType;
+import com.example.scoi.domain.myWallet.enums.TopupType;
+import com.example.scoi.domain.myWallet.exception.MyWalletException;
+import com.example.scoi.domain.myWallet.exception.code.MyWalletErrorCode;
+import com.example.scoi.domain.myWallet.exception.code.MyWalletSuccessCode;
+import com.example.scoi.domain.myWallet.service.MyWalletService;
+import com.example.scoi.global.apiPayload.ApiResponse;
+import com.example.scoi.global.security.userdetails.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-public class MyWalletController {
+@RequestMapping("/api/mywallet")
+public class MyWalletController implements MyWalletControllerDocs {
+
+    private final MyWalletService myWalletService;
+
+    // 거래 내역 전체 조회 (입출금)
+    @GetMapping("/transactions/remit")
+    public ApiResponse<MyWalletResDTO.TransactionListDTO> getRemitTransactions(
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+            @RequestParam(defaultValue = "ALL") RemitType type,
+            @RequestParam(defaultValue = "ONE_MONTH") PeriodType period,
+            @RequestParam(defaultValue = "desc") String order,
+            @RequestParam(defaultValue = "20") int limit,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        validateOrderParam(order);
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+
+        MyWalletResDTO.TransactionListDTO result = myWalletService.getRemitTransactions(
+                user.getUsername(),
+                exchangeType,
+                type,
+                period,
+                order,
+                safeLimit
+        );
+
+        return ApiResponse.onSuccess(MyWalletSuccessCode.REMIT_TRANSACTIONS_SUCCESS, result);
+    }
+
+    // 거래 내역 전체 조회 (충전)
+    @GetMapping("/transactions/topups")
+    public ApiResponse<MyWalletResDTO.TopupTransactionListDTO> getTopupTransactions(
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+            @RequestParam(defaultValue = "ALL") TopupType type,
+            @RequestParam(defaultValue = "DONE") OrderState state,
+            @RequestParam(defaultValue = "THREE_MONTHS") PeriodType period,
+            @RequestParam(defaultValue = "desc") String order,
+            @RequestParam(defaultValue = "20") int limit,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        validateOrderParam(order);
+        int safeLimit = Math.max(1, Math.min(limit, 100));
+
+        MyWalletResDTO.TopupTransactionListDTO result = myWalletService.getTopupTransactions(
+                user.getUsername(),
+                exchangeType,
+                type,
+                state,
+                period,
+                order,
+                safeLimit
+        );
+
+        return ApiResponse.onSuccess(MyWalletSuccessCode.TOPUP_TRANSACTIONS_SUCCESS, result);
+    }
+
+    // 거래내역 상세 조회 (입출금 + 충전 통합)
+    @GetMapping("/transactions/detail")
+    public ApiResponse<MyWalletResDTO.TransactionDetailDTO> getTransactionDetail(
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+            @RequestParam DetailCategory category,
+            @RequestParam(required = false) RemitType remitType,
+            @RequestParam String uuid,
+            @RequestParam(required = false) String currency,
+            @AuthenticationPrincipal CustomUserDetails user
+    ) {
+        // uuid 필수 검증
+        if (uuid == null || uuid.isBlank()) {
+            throw new MyWalletException(MyWalletErrorCode.INVALID_UUID_PARAM);
+        }
+
+        // category=REMIT일 때 remitType 필수 검증
+        if (category == DetailCategory.REMIT && (remitType == null || remitType == RemitType.ALL)) {
+            throw new MyWalletException(MyWalletErrorCode.INVALID_DETAIL_PARAM);
+        }
+
+        MyWalletResDTO.TransactionDetailDTO result = myWalletService.getTransactionDetail(
+                user.getUsername(),
+                exchangeType,
+                category,
+                remitType,
+                uuid,
+                currency
+        );
+
+        return ApiResponse.onSuccess(MyWalletSuccessCode.TRANSACTION_DETAIL_SUCCESS, result);
+    }
+
+    /**
+     * order 파라미터 검증 (desc 또는 asc만 허용)
+     */
+    private void validateOrderParam(String order) {
+        if (!"desc".equalsIgnoreCase(order) && !"asc".equalsIgnoreCase(order)) {
+            throw new MyWalletException(MyWalletErrorCode.INVALID_ORDER_PARAM);
+        }
+    }
 }

--- a/src/main/java/com/example/scoi/domain/myWallet/controller/MyWalletControllerDocs.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/controller/MyWalletControllerDocs.java
@@ -1,0 +1,97 @@
+package com.example.scoi.domain.myWallet.controller;
+
+import com.example.scoi.domain.member.enums.ExchangeType;
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.enums.DetailCategory;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+import com.example.scoi.domain.myWallet.enums.RemitType;
+import com.example.scoi.domain.myWallet.enums.TopupType;
+import com.example.scoi.global.apiPayload.ApiResponse;
+import com.example.scoi.global.security.userdetails.CustomUserDetails;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.RequestParam;
+
+@Tag(name = "내 지갑 API", description = "거래 내역 조회, 자산 관리")
+public interface MyWalletControllerDocs {
+
+    @Operation(
+            summary = "거래 내역 전체 조회(입출금) API By 원종호",
+            description = "거래소의 코인(USDT/USDC) 입금/출금 내역을 통합 조회합니다. " +
+                    "기간, 거래 유형(입금/출금/전체), 정렬 순서, 조회 건수를 지정할 수 있습니다."
+    )
+    ApiResponse<MyWalletResDTO.TransactionListDTO> getRemitTransactions(
+            @Parameter(description = "거래소 타입 (BITHUMB, UPBIT)", example = "BITHUMB")
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+
+            @Parameter(description = "조회 유형 (ALL: 전체, DEPOSIT: 입금, WITHDRAW: 출금)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") RemitType type,
+
+            @Parameter(description = "조회 기간 (TODAY, ONE_MONTH, THREE_MONTHS, SIX_MONTHS)", example = "ONE_MONTH")
+            @RequestParam(defaultValue = "ONE_MONTH") PeriodType period,
+
+            @Parameter(description = "정렬 순서 (desc: 최신순, asc: 과거순)", example = "desc")
+            @RequestParam(defaultValue = "desc") String order,
+
+            @Parameter(description = "조회 건수 (최대 100)", example = "20")
+            @RequestParam(defaultValue = "20") int limit,
+
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "거래 내역 전체 조회(충전) API By 원종호",
+            description = "거래소의 스테이블코인(KRW-USDT/KRW-USDC) 주문(충전/현금교환) 내역을 조회합니다. " +
+                    "기간, 거래 유형(충전/현금교환/전체), 주문 상태(완료/대기/취소), 정렬 순서, 조회 건수를 지정할 수 있습니다. " +
+                    "업비트의 경우 종료 주문은 7일 단위 윈도우로 조회하며, 최대 28회 API 호출 제한이 적용됩니다."
+    )
+    ApiResponse<MyWalletResDTO.TopupTransactionListDTO> getTopupTransactions(
+            @Parameter(description = "거래소 타입 (BITHUMB, UPBIT)", example = "BITHUMB")
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+
+            @Parameter(description = "조회 유형 (ALL: 전체, CHARGE: 충전/매수, CASH_EXCHANGE: 현금교환/매도)", example = "ALL")
+            @RequestParam(defaultValue = "ALL") TopupType type,
+
+            @Parameter(description = "주문 상태 (DONE: 완료, WAIT: 대기, CANCEL: 취소)", example = "DONE")
+            @RequestParam(defaultValue = "DONE") OrderState state,
+
+            @Parameter(description = "조회 기간 (TODAY, ONE_MONTH, THREE_MONTHS, SIX_MONTHS)", example = "THREE_MONTHS")
+            @RequestParam(defaultValue = "THREE_MONTHS") PeriodType period,
+
+            @Parameter(description = "정렬 순서 (desc: 최신순, asc: 과거순)", example = "desc")
+            @RequestParam(defaultValue = "desc") String order,
+
+            @Parameter(description = "조회 건수 (최대 100)", example = "20")
+            @RequestParam(defaultValue = "20") int limit,
+
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+
+    @Operation(
+            summary = "거래내역 상세 조회 API By 원종호",
+            description = "입출금 또는 충전 거래의 상세 내역을 UUID로 조회합니다. " +
+                    "category=REMIT이면 입금/출금 상세, category=TOPUP이면 주문 상세(체결 내역 포함)를 반환합니다. " +
+                    "입출금 조회 시 remitType(DEPOSIT/WITHDRAW) 파라미터가 필수입니다."
+    )
+    ApiResponse<MyWalletResDTO.TransactionDetailDTO> getTransactionDetail(
+            @Parameter(description = "거래소 타입 (BITHUMB, UPBIT)", example = "BITHUMB")
+            @RequestParam(defaultValue = "BITHUMB") ExchangeType exchangeType,
+
+            @Parameter(description = "조회 카테고리 (REMIT: 입출금, TOPUP: 충전)", example = "REMIT")
+            @RequestParam DetailCategory category,
+
+            @Parameter(description = "입출금 구분 (DEPOSIT: 입금, WITHDRAW: 출금) - category=REMIT일 때 필수", example = "DEPOSIT")
+            @RequestParam(required = false) RemitType remitType,
+
+            @Parameter(description = "거래 UUID", example = "550e8400-e29b-41d4-a716-446655440000")
+            @RequestParam String uuid,
+
+            @Parameter(description = "통화 코드 (USDT, USDC 등) - category=REMIT일 때 선택", example = "USDT")
+            @RequestParam(required = false) String currency,
+
+            @AuthenticationPrincipal CustomUserDetails user
+    );
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/converter/MyWalletConverter.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/converter/MyWalletConverter.java
@@ -1,4 +1,280 @@
 package com.example.scoi.domain.myWallet.converter;
 
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.dto.TopupClientDTO;
+import com.example.scoi.domain.myWallet.enums.RemitType;
+import com.example.scoi.global.client.dto.BithumbResDTO;
+import com.example.scoi.global.client.dto.UpbitResDTO;
+
+import java.util.Collections;
+import java.util.List;
+
 public class MyWalletConverter {
+
+    // ==================== 빗썸 변환 ====================
+
+    public static MyWalletResDTO.TransactionDTO fromBithumbDeposit(BithumbResDTO.GetDeposit deposit) {
+        return MyWalletResDTO.TransactionDTO.builder()
+                .type(RemitType.DEPOSIT)
+                .uuid(deposit.uuid())
+                .currency(deposit.currency())
+                .state(deposit.state())
+                .amount(deposit.amount())
+                .fee(deposit.fee())
+                .txid(deposit.txid())
+                .createdAt(deposit.created_at())
+                .doneAt(deposit.done_at())
+                .transactionType(deposit.transaction_type())
+                .build();
+    }
+
+    public static MyWalletResDTO.TransactionDTO fromBithumbWithdraw(BithumbResDTO.GetWithdraw withdraw) {
+        return MyWalletResDTO.TransactionDTO.builder()
+                .type(RemitType.WITHDRAW)
+                .uuid(withdraw.uuid())
+                .currency(withdraw.currency())
+                .state(withdraw.state())
+                .amount(withdraw.amount())
+                .fee(withdraw.fee())
+                .txid(withdraw.txid())
+                .createdAt(withdraw.created_at())
+                .doneAt(withdraw.done_at())
+                .transactionType(withdraw.transaction_type())
+                .build();
+    }
+
+    // ==================== 업비트 변환 ====================
+
+    public static MyWalletResDTO.TransactionDTO fromUpbitDeposit(UpbitResDTO.GetDeposit deposit) {
+        return MyWalletResDTO.TransactionDTO.builder()
+                .type(RemitType.DEPOSIT)
+                .uuid(deposit.uuid())
+                .currency(deposit.currency())
+                .state(deposit.state())
+                .amount(deposit.amount())
+                .fee(deposit.fee())
+                .txid(deposit.txid())
+                .createdAt(deposit.created_at())
+                .doneAt(deposit.done_at())
+                .transactionType(deposit.transaction_type())
+                .build();
+    }
+
+    public static MyWalletResDTO.TransactionDTO fromUpbitWithdraw(UpbitResDTO.GetWithdraw withdraw) {
+        return MyWalletResDTO.TransactionDTO.builder()
+                .type(RemitType.WITHDRAW)
+                .uuid(withdraw.uuid())
+                .currency(withdraw.currency())
+                .state(withdraw.state())
+                .amount(withdraw.amount())
+                .fee(withdraw.fee())
+                .txid(withdraw.txid())
+                .createdAt(withdraw.created_at())
+                .doneAt(withdraw.done_at())
+                .transactionType(withdraw.transaction_type())
+                .build();
+    }
+
+    // ==================== 잔량 설정 ====================
+
+    /**
+     * 기존 TransactionDTO에 balance(잔량)를 설정한 새 인스턴스를 반환합니다.
+     */
+    public static MyWalletResDTO.TransactionDTO withBalance(MyWalletResDTO.TransactionDTO tx, String balance) {
+        return MyWalletResDTO.TransactionDTO.builder()
+                .type(tx.type())
+                .uuid(tx.uuid())
+                .currency(tx.currency())
+                .state(tx.state())
+                .amount(tx.amount())
+                .fee(tx.fee())
+                .txid(tx.txid())
+                .createdAt(tx.createdAt())
+                .doneAt(tx.doneAt())
+                .transactionType(tx.transactionType())
+                .balance(balance)
+                .build();
+    }
+
+    // ==================== 빗썸 주문 변환 ====================
+
+    public static MyWalletResDTO.TopupTransactionDTO fromBithumbOrder(TopupClientDTO.BithumbOrder order) {
+        return MyWalletResDTO.TopupTransactionDTO.builder()
+                .uuid(order.uuid())
+                .market(order.market())
+                .side(order.side())
+                .state(order.state())
+                .createdAt(order.createdAt())
+                .volume(order.volume())
+                .executedVolume(order.executedVolume())
+                .build();
+    }
+
+    // ==================== 업비트 주문 변환 ====================
+
+    public static MyWalletResDTO.TopupTransactionDTO fromUpbitOrder(TopupClientDTO.UpbitOrder order) {
+        return MyWalletResDTO.TopupTransactionDTO.builder()
+                .uuid(order.uuid())
+                .market(order.market())
+                .side(order.side())
+                .state(order.state())
+                .createdAt(order.createdAt())
+                .volume(order.volume())
+                .executedVolume(order.executedVolume())
+                .build();
+    }
+
+    // ==================== 상세 조회 변환 ====================
+
+    /**
+     * 빗썸 개별 입금 -> RemitDetailDTO
+     */
+    public static MyWalletResDTO.RemitDetailDTO fromBithumbDepositDetail(BithumbResDTO.GetDeposit deposit) {
+        return MyWalletResDTO.RemitDetailDTO.builder()
+                .type(deposit.type())
+                .uuid(deposit.uuid())
+                .currency(deposit.currency())
+                .netType(deposit.net_type())
+                .txid(deposit.txid())
+                .state(deposit.state())
+                .createdAt(deposit.created_at())
+                .doneAt(deposit.done_at())
+                .amount(deposit.amount())
+                .fee(deposit.fee())
+                .transactionType(deposit.transaction_type())
+                .build();
+    }
+
+    /**
+     * 빗썸 개별 출금 -> RemitDetailDTO
+     */
+    public static MyWalletResDTO.RemitDetailDTO fromBithumbWithdrawDetail(BithumbResDTO.GetWithdraw withdraw) {
+        return MyWalletResDTO.RemitDetailDTO.builder()
+                .type(withdraw.type())
+                .uuid(withdraw.uuid())
+                .currency(withdraw.currency())
+                .netType(withdraw.net_type())
+                .txid(withdraw.txid())
+                .state(withdraw.state())
+                .createdAt(withdraw.created_at())
+                .doneAt(withdraw.done_at())
+                .amount(withdraw.amount())
+                .fee(withdraw.fee())
+                .transactionType(withdraw.transaction_type())
+                .build();
+    }
+
+    /**
+     * 업비트 개별 입금 -> RemitDetailDTO
+     */
+    public static MyWalletResDTO.RemitDetailDTO fromUpbitDepositDetail(UpbitResDTO.GetDeposit deposit) {
+        return MyWalletResDTO.RemitDetailDTO.builder()
+                .type(deposit.type())
+                .uuid(deposit.uuid())
+                .currency(deposit.currency())
+                .netType(deposit.net_type())
+                .txid(deposit.txid())
+                .state(deposit.state())
+                .createdAt(deposit.created_at())
+                .doneAt(deposit.done_at())
+                .amount(deposit.amount())
+                .fee(deposit.fee())
+                .transactionType(deposit.transaction_type())
+                .build();
+    }
+
+    /**
+     * 업비트 개별 출금 -> RemitDetailDTO
+     */
+    public static MyWalletResDTO.RemitDetailDTO fromUpbitWithdrawDetail(UpbitResDTO.GetWithdraw withdraw) {
+        return MyWalletResDTO.RemitDetailDTO.builder()
+                .type(withdraw.type())
+                .uuid(withdraw.uuid())
+                .currency(withdraw.currency())
+                .netType(withdraw.net_type())
+                .txid(withdraw.txid())
+                .state(withdraw.state())
+                .createdAt(withdraw.created_at())
+                .doneAt(withdraw.done_at())
+                .amount(withdraw.amount())
+                .fee(withdraw.fee())
+                .transactionType(withdraw.transaction_type())
+                .build();
+    }
+
+    /**
+     * 빗썸 개별 주문 -> TopupDetailDTO
+     */
+    public static MyWalletResDTO.TopupDetailDTO fromBithumbOrderDetail(BithumbResDTO.GetOrder order) {
+        List<MyWalletResDTO.TradeDTO> trades = order.trades() != null
+                ? order.trades().stream()
+                    .map(t -> MyWalletResDTO.TradeDTO.builder()
+                            .market(t.market())
+                            .uuid(t.uuid())
+                            .price(t.price())
+                            .volume(t.volume())
+                            .funds(t.funds())
+                            .side(t.side())
+                            .createdAt(t.created_at())
+                            .build())
+                    .toList()
+                : Collections.emptyList();
+
+        return MyWalletResDTO.TopupDetailDTO.builder()
+                .uuid(order.uuid())
+                .market(order.market())
+                .side(order.side())
+                .ordType(order.ord_type())
+                .price(order.price())
+                .state(order.state())
+                .createdAt(order.created_at())
+                .volume(order.volume())
+                .remainingVolume(order.remaining_volume())
+                .executedVolume(order.executed_volume())
+                .reservedFee(order.reserved_fee())
+                .remainingFee(order.remaining_fee())
+                .paidFee(order.paid_fee())
+                .locked(order.locked())
+                .tradesCount(order.trades_count())
+                .trades(trades)
+                .build();
+    }
+
+    /**
+     * 업비트 개별 주문 -> TopupDetailDTO
+     */
+    public static MyWalletResDTO.TopupDetailDTO fromUpbitOrderDetail(UpbitResDTO.GetOrder order) {
+        List<MyWalletResDTO.TradeDTO> trades = order.trades() != null
+                ? order.trades().stream()
+                    .map(t -> MyWalletResDTO.TradeDTO.builder()
+                            .market(t.market())
+                            .uuid(t.uuid())
+                            .price(t.price())
+                            .volume(t.volume())
+                            .funds(t.funds())
+                            .side(t.side())
+                            .createdAt(t.created_at())
+                            .build())
+                    .toList()
+                : Collections.emptyList();
+
+        return MyWalletResDTO.TopupDetailDTO.builder()
+                .uuid(order.uuid())
+                .market(order.market())
+                .side(order.side())
+                .ordType(order.ord_type())
+                .price(order.price())
+                .state(order.state())
+                .createdAt(order.created_at())
+                .volume(order.volume())
+                .remainingVolume(order.remaining_volume())
+                .executedVolume(order.executed_volume())
+                .reservedFee(order.reserved_fee())
+                .remainingFee(order.remaining_fee())
+                .paidFee(order.paid_fee())
+                .locked(order.locked())
+                .tradesCount(order.trades_count())
+                .trades(trades)
+                .build();
+    }
 }

--- a/src/main/java/com/example/scoi/domain/myWallet/dto/BalanceClientDTO.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/dto/BalanceClientDTO.java
@@ -1,0 +1,21 @@
+package com.example.scoi.domain.myWallet.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * 거래소 계좌 잔고 조회 API 원본 응답 DTO
+ * GET /v1/accounts
+ */
+public class BalanceClientDTO {
+
+    /**
+     * 빗썸/업비트 계좌 정보
+     * 두 거래소 모두 동일한 응답 구조
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record AccountInfo(
+            String currency,        // 화폐 코드 (USDT, USDC 등)
+            String balance,         // 주문 가능 수량
+            String locked           // 주문 중 묶여있는 수량
+    ) {}
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/dto/MyWalletResDTO.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/dto/MyWalletResDTO.java
@@ -1,5 +1,127 @@
 package com.example.scoi.domain.myWallet.dto;
 
+import com.example.scoi.domain.myWallet.enums.RemitType;
+import lombok.Builder;
+
+import java.util.List;
+
 public class MyWalletResDTO {
-    // 응답 DTO 정의
+
+    /**
+     * 개별 거래 내역 (입금/출금 통합)
+     */
+    @Builder
+    public record TransactionDTO(
+            RemitType type,              // DEPOSIT 또는 WITHDRAW
+            String uuid,                 // 거래 고유 ID
+            String currency,             // 화폐 코드 (USDT, USDC 등)
+            String state,                // 거래 상태 (PROCESSING, ACCEPTED, CANCELLED 등)
+            String amount,               // 금액
+            String fee,                  // 수수료
+            String txid,                 // 거래소 트랜잭션 ID
+            String createdAt,            // 생성 시간
+            String doneAt,               // 완료 시간
+            String transactionType,      // 거래 유형 (default, internal 등)
+            String balance               // 해당 통화의 거래 후 잔량
+    ) {}
+
+    /**
+     * 거래 내역 목록 응답
+     */
+    @Builder
+    public record TransactionListDTO(
+            List<TransactionDTO> transactions,
+            int totalCount               // 필터링 후 반환된 건수
+    ) {}
+
+    /**
+     * 개별 충전 거래 내역 (주문)
+     */
+    @Builder
+    public record TopupTransactionDTO(
+            String uuid,                 // 주문 고유 ID (상세 조회용 메타데이터)
+            String market,               // 마켓 코드 (KRW-USDT, KRW-USDC)
+            String side,                 // 주문 방향 (bid: 충전, ask: 현금교환)
+            String state,                // 주문 상태 (done, wait, cancel)
+            String createdAt,            // 생성 시간
+            String volume,               // 주문량
+            String executedVolume        // 체결량
+    ) {}
+
+    /**
+     * 충전 거래 내역 목록 응답
+     */
+    @Builder
+    public record TopupTransactionListDTO(
+            List<TopupTransactionDTO> transactions,
+            int totalCount               // 필터링 후 반환된 건수
+    ) {}
+
+    // ==================== 상세 조회 ====================
+
+    /**
+     * 입출금 상세 조회 응답 (개별 입금/출금의 전체 필드)
+     */
+    @Builder
+    public record RemitDetailDTO(
+            String type,                 // 입출금 종류 (deposit, withdraw)
+            String uuid,                 // 고유 ID
+            String currency,             // 화폐 코드
+            String netType,              // 네트워크 타입
+            String txid,                 // 트랜잭션 ID
+            String state,                // 상태
+            String createdAt,            // 생성 시간
+            String doneAt,               // 완료 시간
+            String amount,               // 금액
+            String fee,                  // 수수료
+            String transactionType       // 거래 유형 (default, internal 등)
+    ) {}
+
+    /**
+     * 충전 상세 조회 응답 (개별 주문의 전체 필드 + 체결 내역)
+     */
+    @Builder
+    public record TopupDetailDTO(
+            String uuid,                 // 주문 고유 ID
+            String market,               // 마켓 코드 (KRW-USDT, KRW-USDC)
+            String side,                 // 주문 방향 (bid/ask)
+            String ordType,              // 주문 유형 (limit, price, market 등)
+            String price,                // 주문 가격
+            String state,                // 주문 상태
+            String createdAt,            // 생성 시간
+            String volume,               // 주문량
+            String remainingVolume,      // 잔여 주문량
+            String executedVolume,       // 체결량
+            String reservedFee,          // 예약된 수수료
+            String remainingFee,         // 잔여 수수료
+            String paidFee,              // 지불된 수수료
+            String locked,               // 묶인 금액
+            String tradesCount,          // 체결 건수
+            List<TradeDTO> trades        // 체결 내역
+    ) {}
+
+    /**
+     * 개별 체결 내역
+     */
+    @Builder
+    public record TradeDTO(
+            String market,               // 마켓 코드
+            String uuid,                 // 체결 고유 ID
+            String price,                // 체결 가격
+            String volume,               // 체결량
+            String funds,                // 체결 금액
+            String side,                 // 체결 방향
+            String createdAt             // 체결 시간
+    ) {}
+
+    /**
+     * 거래내역 상세 조회 통합 응답
+     * category에 따라 remitDetail 또는 topupDetail 중 하나가 non-null
+     */
+    @Builder
+    public record TransactionDetailDTO(
+            String category,             // "REMIT" 또는 "TOPUP"
+            RemitDetailDTO remitDetail,  // 입출금 상세 (category=REMIT일 때)
+            TopupDetailDTO topupDetail   // 충전 상세 (category=TOPUP일 때)
+    ) {}
 }

--- a/src/main/java/com/example/scoi/domain/myWallet/dto/TopupClientDTO.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/dto/TopupClientDTO.java
@@ -1,0 +1,47 @@
+package com.example.scoi.domain.myWallet.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * 거래소 주문 리스트 API 원본 응답 DTO
+ * global/client/dto 수정 없이 myWallet 도메인 내에 정의
+ */
+public class TopupClientDTO {
+
+    /**
+     * 빗썸 주문 리스트 조회 응답
+     * GET /v1/orders
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record BithumbOrder(
+            String uuid,
+            String side,
+            @JsonProperty("ord_type") String ordType,
+            String price,
+            String state,
+            String market,
+            String volume,
+            @JsonProperty("remaining_volume") String remainingVolume,
+            @JsonProperty("executed_volume") String executedVolume,
+            @JsonProperty("created_at") String createdAt
+    ) {}
+
+    /**
+     * 업비트 주문 목록 조회 응답
+     * GET /v1/orders/closed, GET /v1/orders/open
+     */
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record UpbitOrder(
+            String uuid,
+            String side,
+            @JsonProperty("ord_type") String ordType,
+            String price,
+            String state,
+            String market,
+            String volume,
+            @JsonProperty("remaining_volume") String remainingVolume,
+            @JsonProperty("executed_volume") String executedVolume,
+            @JsonProperty("created_at") String createdAt
+    ) {}
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/enums/DetailCategory.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/enums/DetailCategory.java
@@ -1,0 +1,5 @@
+package com.example.scoi.domain.myWallet.enums;
+
+public enum DetailCategory {
+    REMIT, TOPUP
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/enums/OrderState.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/enums/OrderState.java
@@ -1,0 +1,14 @@
+package com.example.scoi.domain.myWallet.enums;
+
+public enum OrderState {
+    DONE,       // 완료
+    WAIT,       // 대기
+    CANCEL;     // 취소
+
+    /**
+     * 거래소 API에 전달할 state 문자열을 반환합니다.
+     */
+    public String toApiValue() {
+        return this.name().toLowerCase();
+    }
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/enums/PeriodType.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/enums/PeriodType.java
@@ -1,0 +1,27 @@
+package com.example.scoi.domain.myWallet.enums;
+
+import java.time.LocalDate;
+
+public enum PeriodType {
+    TODAY,
+    ONE_MONTH,
+    THREE_MONTHS,
+    SIX_MONTHS;
+
+    /**
+     * 기간 시작일을 반환합니다.
+     * TODAY: 오늘 00:00:00
+     * ONE_MONTH: 1개월 전
+     * THREE_MONTHS: 3개월 전
+     * SIX_MONTHS: 6개월 전
+     */
+    public LocalDate getStartDate() {
+        LocalDate today = LocalDate.now();
+        return switch (this) {
+            case TODAY -> today;
+            case ONE_MONTH -> today.minusMonths(1);
+            case THREE_MONTHS -> today.minusMonths(3);
+            case SIX_MONTHS -> today.minusMonths(6);
+        };
+    }
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/enums/RemitType.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/enums/RemitType.java
@@ -1,0 +1,5 @@
+package com.example.scoi.domain.myWallet.enums;
+
+public enum RemitType {
+    ALL, DEPOSIT, WITHDRAW
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/enums/TopupType.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/enums/TopupType.java
@@ -1,0 +1,7 @@
+package com.example.scoi.domain.myWallet.enums;
+
+public enum TopupType {
+    ALL,            // 전체
+    CHARGE,         // 충전 (매수, bid)
+    CASH_EXCHANGE   // 현금 교환 (매도, ask)
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/exception/code/MyWalletErrorCode.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/exception/code/MyWalletErrorCode.java
@@ -9,7 +9,54 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum MyWalletErrorCode implements BaseErrorCode {
 
-    // 도메인별 실패 코드 정의
+    // 400 에러
+    EXCHANGE_API_ERROR(HttpStatus.BAD_REQUEST,
+            "MYWALLET400_1",
+            "거래소 API 요청을 처리하지 못했습니다."),
+
+    INVALID_EXCHANGE_TYPE(HttpStatus.BAD_REQUEST,
+            "MYWALLET400_2",
+            "잘못된 거래소 타입입니다."),
+
+    INVALID_ORDER_PARAM(HttpStatus.BAD_REQUEST,
+            "MYWALLET400_3",
+            "정렬 순서는 'desc'(최신순) 또는 'asc'(과거순)만 가능합니다."),
+
+    INVALID_DETAIL_PARAM(HttpStatus.BAD_REQUEST,
+            "MYWALLET400_4",
+            "입출금 상세 조회 시 remitType(DEPOSIT 또는 WITHDRAW)은 필수입니다."),
+
+    INVALID_UUID_PARAM(HttpStatus.BAD_REQUEST,
+            "MYWALLET400_5",
+            "uuid는 필수 파라미터입니다."),
+
+    // 401 에러
+    INSUFFICIENT_API_PERMISSION(HttpStatus.UNAUTHORIZED,
+            "MYWALLET401_1",
+            "거래소 API 키의 권한이 부족합니다."),
+
+    // 404 에러
+    API_KEY_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "MYWALLET404_1",
+            "거래소 API 키가 등록되어 있지 않습니다."),
+
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND,
+            "MYWALLET404_2",
+            "사용자를 찾을 수 없습니다."),
+
+    // 429 에러
+    EXCHANGE_RATE_LIMIT(HttpStatus.TOO_MANY_REQUESTS,
+            "MYWALLET429_1",
+            "거래소 API 호출 한도를 초과했습니다. 잠시 후 다시 시도해 주세요."),
+
+    // 500 에러
+    EXCHANGE_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR,
+            "MYWALLET500_1",
+            "거래소 서버에 일시적인 오류가 발생했습니다."),
+
+    EXCHANGE_TIMEOUT(HttpStatus.GATEWAY_TIMEOUT,
+            "MYWALLET504_1",
+            "거래소 API 응답 시간이 초과되었습니다."),
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/example/scoi/domain/myWallet/exception/code/MyWalletSuccessCode.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/exception/code/MyWalletSuccessCode.java
@@ -1,0 +1,26 @@
+package com.example.scoi.domain.myWallet.exception.code;
+
+import com.example.scoi.global.apiPayload.code.BaseSuccessCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum MyWalletSuccessCode implements BaseSuccessCode {
+
+    REMIT_TRANSACTIONS_SUCCESS(HttpStatus.OK,
+            "MYWALLET200_1",
+            "거래 내역을 성공적으로 조회했습니다."),
+    TOPUP_TRANSACTIONS_SUCCESS(HttpStatus.OK,
+            "MYWALLET200_2",
+            "충전 거래 내역을 성공적으로 조회했습니다."),
+    TRANSACTION_DETAIL_SUCCESS(HttpStatus.OK,
+            "MYWALLET200_3",
+            "거래 상세 내역을 성공적으로 조회했습니다."),
+    ;
+
+    private final HttpStatus status;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/example/scoi/domain/myWallet/service/MyWalletService.java
+++ b/src/main/java/com/example/scoi/domain/myWallet/service/MyWalletService.java
@@ -1,4 +1,400 @@
 package com.example.scoi.domain.myWallet.service;
 
+import com.example.scoi.domain.member.entity.Member;
+import com.example.scoi.domain.member.enums.ExchangeType;
+import com.example.scoi.domain.member.repository.MemberRepository;
+import com.example.scoi.domain.myWallet.client.MyWalletExchangeClient;
+import com.example.scoi.domain.myWallet.client.adapter.MyWalletBithumbClient;
+import com.example.scoi.domain.myWallet.client.adapter.MyWalletUpbitClient;
+import com.example.scoi.domain.myWallet.converter.MyWalletConverter;
+import com.example.scoi.domain.myWallet.dto.MyWalletResDTO;
+import com.example.scoi.domain.myWallet.enums.DetailCategory;
+import com.example.scoi.domain.myWallet.enums.OrderState;
+import com.example.scoi.domain.myWallet.enums.PeriodType;
+import com.example.scoi.domain.myWallet.enums.RemitType;
+import com.example.scoi.domain.myWallet.enums.TopupType;
+import com.example.scoi.domain.myWallet.exception.MyWalletException;
+import com.example.scoi.domain.myWallet.exception.code.MyWalletErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
 public class MyWalletService {
+
+    private final MemberRepository memberRepository;
+    private final MyWalletBithumbClient myWalletBithumbClient;
+    private final MyWalletUpbitClient myWalletUpbitClient;
+
+    /**
+     * 거래 내역(입출금) 전체 조회
+     *
+     * @param phoneNumber  사용자 휴대폰 번호
+     * @param exchangeType 거래소 타입 (BITHUMB, UPBIT)
+     * @param remitType    조회 유형 (ALL, DEPOSIT, WITHDRAW)
+     * @param periodType   기간 (TODAY, ONE_MONTH, THREE_MONTHS, SIX_MONTHS)
+     * @param order        정렬 방향 (desc, asc)
+     * @param limit        조회 건수
+     * @return 거래 내역 목록 (각 항목에 해당 통화의 잔량 포함)
+     */
+    public MyWalletResDTO.TransactionListDTO getRemitTransactions(
+            String phoneNumber,
+            ExchangeType exchangeType,
+            RemitType remitType,
+            PeriodType periodType,
+            String order,
+            int limit
+    ) {
+        // 1. 사용자 존재 여부 확인
+        memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new MyWalletException(MyWalletErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 거래소 클라이언트 선택
+        MyWalletExchangeClient apiClient = getApiClient(exchangeType);
+
+        // 3. 현재 잔고 조회 + 입금/출금 데이터 모두 조회 (잔량 계산을 위해 항상 양쪽 다 가져옴)
+        Map<String, BigDecimal> currentBalances;
+        List<MyWalletResDTO.TransactionDTO> allTransactions = new ArrayList<>();
+
+        try {
+            currentBalances = apiClient.getBalances(phoneNumber);
+
+            List<MyWalletResDTO.TransactionDTO> deposits = apiClient.getDeposits(phoneNumber);
+            allTransactions.addAll(deposits);
+
+            List<MyWalletResDTO.TransactionDTO> withdraws = apiClient.getWithdraws(phoneNumber);
+            allTransactions.addAll(withdraws);
+        } catch (MyWalletException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("거래소 API 호출 실패 - exchangeType: {}, phoneNumber: {}", exchangeType, phoneNumber, e);
+            throw new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+        }
+
+        // 4. 최신순 정렬 (잔량 역산을 위해 항상 최신순으로 먼저 정렬)
+        List<MyWalletResDTO.TransactionDTO> sortedDesc = allTransactions.stream()
+                .sorted(Comparator.comparing(
+                        MyWalletResDTO.TransactionDTO::createdAt,
+                        Comparator.nullsLast(Comparator.naturalOrder())
+                ).reversed())
+                .toList();
+
+        // 5. 잔량 역산 계산 (최신순으로 순회하며 통화별 잔량 계산)
+        //    잔량에 영향을 주는 상태:
+        //    - 입금(DEPOSIT): ACCEPTED (입금 완료)
+        //    - 출금(WITHDRAW): DONE (출금 완료)
+        //    그 외 상태(PROCESSING, WAITING, CANCELLED, REJECTED, FAILED, REFUNDED 등)는 잔량 변화 없음
+        Map<String, BigDecimal> runningBalances = new HashMap<>(currentBalances);
+        List<MyWalletResDTO.TransactionDTO> withBalances = new ArrayList<>();
+
+        for (MyWalletResDTO.TransactionDTO tx : sortedDesc) {
+            String currency = tx.currency();
+            BigDecimal balance = runningBalances.getOrDefault(currency, BigDecimal.ZERO);
+
+            // 현재 거래의 잔량 = 이 거래 직후의 잔량
+            withBalances.add(MyWalletConverter.withBalance(tx, balance.toPlainString()));
+
+            // 완료된 거래만 잔량 역산에 반영
+            if (isBalanceAffectingState(tx.type(), tx.state())) {
+                BigDecimal amount = parseAmount(tx.amount());
+                if (tx.type() == RemitType.DEPOSIT) {
+                    // 입금이었으므로, 이전에는 이 금액만큼 적었음
+                    runningBalances.put(currency, balance.subtract(amount));
+                } else if (tx.type() == RemitType.WITHDRAW) {
+                    // 출금이었으므로, 이전에는 이 금액만큼 많았음
+                    runningBalances.put(currency, balance.add(amount));
+                }
+            }
+        }
+
+        // 6. 기간 필터링
+        LocalDate startDate = periodType.getStartDate();
+        List<MyWalletResDTO.TransactionDTO> filtered = withBalances.stream()
+                .filter(tx -> isWithinPeriod(tx.createdAt(), startDate))
+                .toList();
+
+        // 7. remitType 필터링 (잔량 계산 후 필터링)
+        if (remitType == RemitType.DEPOSIT) {
+            filtered = filtered.stream()
+                    .filter(tx -> tx.type() == RemitType.DEPOSIT)
+                    .toList();
+        } else if (remitType == RemitType.WITHDRAW) {
+            filtered = filtered.stream()
+                    .filter(tx -> tx.type() == RemitType.WITHDRAW)
+                    .toList();
+        }
+
+        // 8. 최종 정렬 (사용자 요청 순서)
+        List<MyWalletResDTO.TransactionDTO> sorted;
+        if ("asc".equalsIgnoreCase(order)) {
+            // 과거순으로 다시 정렬
+            sorted = filtered.stream()
+                    .sorted(Comparator.comparing(
+                            MyWalletResDTO.TransactionDTO::createdAt,
+                            Comparator.nullsLast(Comparator.naturalOrder())
+                    ))
+                    .toList();
+        } else {
+            // 이미 최신순이므로 그대로 사용
+            sorted = filtered;
+        }
+
+        // 9. limit 적용
+        List<MyWalletResDTO.TransactionDTO> result = sorted.stream()
+                .limit(limit)
+                .toList();
+
+        log.info("거래 내역 조회 완료 - exchangeType: {}, remitType: {}, period: {}, 전체: {}, 필터링: {}, 반환: {}",
+                exchangeType, remitType, periodType, allTransactions.size(), filtered.size(), result.size());
+
+        return MyWalletResDTO.TransactionListDTO.builder()
+                .transactions(result)
+                .totalCount(result.size())
+                .build();
+    }
+
+    /**
+     * 충전 거래 내역(주문) 전체 조회
+     *
+     * @param phoneNumber  사용자 휴대폰 번호
+     * @param exchangeType 거래소 타입 (BITHUMB, UPBIT)
+     * @param topupType    조회 유형 (ALL, CHARGE, CASH_EXCHANGE)
+     * @param state        주문 상태 (DONE, WAIT, CANCEL)
+     * @param periodType   기간 (TODAY, ONE_MONTH, THREE_MONTHS, SIX_MONTHS)
+     * @param order        정렬 방향 (desc, asc)
+     * @param limit        조회 건수
+     * @return 충전 거래 내역 목록
+     */
+    public MyWalletResDTO.TopupTransactionListDTO getTopupTransactions(
+            String phoneNumber,
+            ExchangeType exchangeType,
+            TopupType topupType,
+            OrderState state,
+            PeriodType periodType,
+            String order,
+            int limit
+    ) {
+        // 1. 사용자 존재 여부 확인
+        memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new MyWalletException(MyWalletErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 거래소 클라이언트 선택
+        MyWalletExchangeClient apiClient = getApiClient(exchangeType);
+
+        // 3. 거래소에서 주문 데이터 조회
+        List<MyWalletResDTO.TopupTransactionDTO> allOrders;
+        try {
+            if (topupType == TopupType.ALL) {
+                // 전체: bid와 ask 모두 가져와서 합침 (거래소 API에 전체 필터가 없으므로 서버에서 처리)
+                allOrders = apiClient.getOrders(phoneNumber, state, periodType, order, limit);
+            } else {
+                allOrders = apiClient.getOrders(phoneNumber, state, periodType, order, limit);
+            }
+        } catch (MyWalletException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("거래소 주문 API 호출 실패 - exchangeType: {}, phoneNumber: {}", exchangeType, phoneNumber, e);
+            throw new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+        }
+
+        // 4. side 필터링 (충전/현금교환)
+        List<MyWalletResDTO.TopupTransactionDTO> filtered = allOrders;
+        if (topupType == TopupType.CHARGE) {
+            filtered = allOrders.stream()
+                    .filter(tx -> "bid".equals(tx.side()))
+                    .toList();
+        } else if (topupType == TopupType.CASH_EXCHANGE) {
+            filtered = allOrders.stream()
+                    .filter(tx -> "ask".equals(tx.side()))
+                    .toList();
+        }
+
+        // 5. 기간 필터링 (빗썸 데이터는 서버에서 필터링 필요)
+        LocalDate startDate = periodType.getStartDate();
+        filtered = filtered.stream()
+                .filter(tx -> isWithinPeriod(tx.createdAt(), startDate))
+                .toList();
+
+        // 6. 정렬 (created_at 기준)
+        Comparator<MyWalletResDTO.TopupTransactionDTO> comparator =
+                Comparator.comparing(MyWalletResDTO.TopupTransactionDTO::createdAt, Comparator.nullsLast(Comparator.naturalOrder()));
+
+        if ("asc".equalsIgnoreCase(order)) {
+            // 과거순
+        } else {
+            // 최신순 (기본값)
+            comparator = comparator.reversed();
+        }
+
+        List<MyWalletResDTO.TopupTransactionDTO> sorted = filtered.stream()
+                .sorted(comparator)
+                .toList();
+
+        // 7. limit 적용
+        List<MyWalletResDTO.TopupTransactionDTO> result = sorted.stream()
+                .limit(limit)
+                .toList();
+
+        log.info("충전 거래 내역 조회 완료 - exchangeType: {}, topupType: {}, state: {}, period: {}, 전체: {}, 필터링: {}, 반환: {}",
+                exchangeType, topupType, state, periodType, allOrders.size(), filtered.size(), result.size());
+
+        return MyWalletResDTO.TopupTransactionListDTO.builder()
+                .transactions(result)
+                .totalCount(result.size())
+                .build();
+    }
+
+    /**
+     * 거래내역 상세 조회 (입출금 + 충전 통합)
+     *
+     * @param phoneNumber    사용자 휴대폰 번호
+     * @param exchangeType   거래소 타입 (BITHUMB, UPBIT)
+     * @param category       조회 카테고리 (REMIT: 입출금, TOPUP: 충전)
+     * @param remitType      입출금 구분 (DEPOSIT, WITHDRAW) - category=REMIT일 때 필수
+     * @param uuid           거래 UUID
+     * @param currency       통화 코드 (USDT, USDC 등, nullable) - category=REMIT일 때 선택
+     * @return 거래 상세 정보
+     */
+    public MyWalletResDTO.TransactionDetailDTO getTransactionDetail(
+            String phoneNumber,
+            ExchangeType exchangeType,
+            DetailCategory category,
+            RemitType remitType,
+            String uuid,
+            String currency
+    ) {
+        // 1. 사용자 존재 여부 확인
+        memberRepository.findByPhoneNumber(phoneNumber)
+                .orElseThrow(() -> new MyWalletException(MyWalletErrorCode.MEMBER_NOT_FOUND));
+
+        // 2. 거래소 클라이언트 선택
+        MyWalletExchangeClient apiClient = getApiClient(exchangeType);
+
+        // 3. 카테고리별 상세 조회
+        try {
+            if (category == DetailCategory.REMIT) {
+                MyWalletResDTO.RemitDetailDTO remitDetail;
+                if (remitType == RemitType.DEPOSIT) {
+                    remitDetail = apiClient.getDepositDetail(phoneNumber, uuid, currency);
+                } else {
+                    remitDetail = apiClient.getWithdrawDetail(phoneNumber, uuid, currency);
+                }
+
+                log.info("입출금 상세 조회 완료 - exchangeType: {}, remitType: {}, uuid: {}",
+                        exchangeType, remitType, uuid);
+
+                return MyWalletResDTO.TransactionDetailDTO.builder()
+                        .category(category.name())
+                        .remitDetail(remitDetail)
+                        .build();
+
+            } else {
+                MyWalletResDTO.TopupDetailDTO topupDetail = apiClient.getOrderDetail(phoneNumber, uuid);
+
+                log.info("충전 상세 조회 완료 - exchangeType: {}, uuid: {}", exchangeType, uuid);
+
+                return MyWalletResDTO.TransactionDetailDTO.builder()
+                        .category(category.name())
+                        .topupDetail(topupDetail)
+                        .build();
+            }
+        } catch (MyWalletException e) {
+            throw e;
+        } catch (Exception e) {
+            log.error("거래 상세 조회 실패 - exchangeType: {}, category: {}, uuid: {}",
+                    exchangeType, category, uuid, e);
+            throw new MyWalletException(MyWalletErrorCode.EXCHANGE_API_ERROR);
+        }
+    }
+
+    /**
+     * 거래소 타입에 따라 적절한 API 클라이언트를 반환합니다.
+     */
+    private MyWalletExchangeClient getApiClient(ExchangeType exchangeType) {
+        return switch (exchangeType) {
+            case BITHUMB -> myWalletBithumbClient;
+            case UPBIT -> myWalletUpbitClient;
+        };
+    }
+
+    /**
+     * 거래가 실제로 잔량에 영향을 주는 완료 상태인지 확인합니다.
+     * - 입금(DEPOSIT): ACCEPTED일 때만 잔량 변화
+     * - 출금(WITHDRAW): DONE일 때만 잔량 변화
+     * - 그 외 상태(PROCESSING, WAITING, CANCELLED, REJECTED, FAILED, REFUNDED 등)는 잔량 변화 없음
+     */
+    private boolean isBalanceAffectingState(RemitType type, String state) {
+        if (state == null) {
+            return false;
+        }
+        String upperState = state.toUpperCase();
+        if (type == RemitType.DEPOSIT) {
+            return "ACCEPTED".equals(upperState);
+        } else if (type == RemitType.WITHDRAW) {
+            return "DONE".equals(upperState);
+        }
+        return false;
+    }
+
+    /**
+     * 금액 문자열을 BigDecimal로 파싱합니다.
+     * null이나 빈 값은 0으로 처리합니다.
+     */
+    private BigDecimal parseAmount(String amount) {
+        if (amount == null || amount.isBlank()) {
+            return BigDecimal.ZERO;
+        }
+        try {
+            return new BigDecimal(amount);
+        } catch (NumberFormatException e) {
+            log.warn("금액 파싱 실패 - amount: {}", amount);
+            return BigDecimal.ZERO;
+        }
+    }
+
+    /**
+     * 거래 시간이 기간 내에 포함되는지 확인합니다.
+     * 거래소 API의 created_at 형식: "2025-01-01T12:00:00+09:00" (ISO 8601)
+     */
+    private boolean isWithinPeriod(String createdAt, LocalDate startDate) {
+        if (createdAt == null || createdAt.isBlank()) {
+            return false;
+        }
+
+        try {
+            LocalDateTime transactionDateTime;
+
+            // ISO 8601 오프셋 형식 (예: 2025-01-01T12:00:00+09:00)
+            try {
+                OffsetDateTime offsetDateTime = OffsetDateTime.parse(createdAt);
+                transactionDateTime = offsetDateTime.toLocalDateTime();
+            } catch (DateTimeParseException e) {
+                // 오프셋 없는 형식 (예: 2025-01-01T12:00:00)
+                transactionDateTime = LocalDateTime.parse(createdAt, DateTimeFormatter.ISO_LOCAL_DATE_TIME);
+            }
+
+            LocalDate transactionDate = transactionDateTime.toLocalDate();
+            return !transactionDate.isBefore(startDate);
+
+        } catch (DateTimeParseException e) {
+            log.warn("거래 시간 파싱 실패 - createdAt: {}", createdAt, e);
+            return false;
+        }
+    }
 }

--- a/src/main/java/com/example/scoi/global/client/dto/BithumbResDTO.java
+++ b/src/main/java/com/example/scoi/global/client/dto/BithumbResDTO.java
@@ -216,6 +216,22 @@ public class BithumbResDTO {
             String secondary_address
     ){}
 
+    // 개별 출금 조회 (출금 목록 조회 응답 아이템과 동일 구조)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GetWithdraw(
+            String type,
+            String uuid,
+            String currency,
+            String net_type,
+            String txid,
+            String state,
+            String created_at,
+            String done_at,
+            String amount,
+            String fee,
+            String transaction_type
+    ){}
+
     /**
      * 빗썸 전체 계좌 조회 응답 (배열)
      * 공식 문서: https://apidocs.bithumb.com/reference/전체-계좌-조회

--- a/src/main/java/com/example/scoi/global/client/dto/UpbitResDTO.java
+++ b/src/main/java/com/example/scoi/global/client/dto/UpbitResDTO.java
@@ -139,6 +139,22 @@ public class UpbitResDTO {
             String transaction_type
     ){}
 
+    // 개별 출금 조회 (출금 목록 조회 응답 아이템과 동일 구조)
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public record GetWithdraw(
+            String type,
+            String uuid,
+            String currency,
+            String net_type,
+            String txid,
+            String state,
+            String created_at,
+            String done_at,
+            String amount,
+            String fee,
+            String transaction_type
+    ){}
+
     // 주문 가능 정보 조회
     @JsonIgnoreProperties(ignoreUnknown = true) // DTO에 정의되지 않은 필드들이 와도 무시해달라는 설정정 - 추후 추가될 필드들을 위해 필요요
 


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [ ] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #42 

## 📌 개요
-  거래내역 전체 조회 (입출금 / 충전), 거래내역 상세조회 API 개발
특이사항 :
- 원래 커서페이징으로 개발하려 했으나 여러 종류의 API를 호출하여 커서를 설정하기 복잡해짐 -> 오프셋으로 변경

- 거래내역 전체 조회(충전) API에서 업비트의 경우 최대 7일 단위로만 조회할 수 있고 초당 제한이 30회임
-> lazy windowing 기법을 이용해 최적화진행
(만약 6개월단위 조회를 한다면 4x6x2=48번 요청을 해야함(2배 더 곱하는 이유는 필요한 API종류가 2개라서)  이에 대한 해결법 모색 필요)

- 거래내역 전체 조회(입출금)은 잔량 표시를 해야하나 API에서 미제공 -> 현재 보유 자산을 조회하고, 거래내역을 조회해 역추적, 실제 done인 상태만 계산을 진행해 잔량을 표시

## 🔁 변경 사항

## 📸 스크린샷
<img width="1447" height="240" alt="스크린샷 2026-02-09 오전 1 07 02" src="https://github.com/user-attachments/assets/09a2fd32-5d78-4d02-b388-5cb8b01321b4" />

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
