### PR TITLE
♻️ [Refactor] 간편 비밀번호 재설정 API 도메인 이동 (마이페이지 -> 인증)

### DIFF
--- a/src/main/java/com/example/scoi/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/example/scoi/domain/auth/controller/AuthController.java
@@ -4,6 +4,8 @@ import com.example.scoi.domain.auth.code.AuthSuccessCode;
 import com.example.scoi.domain.auth.dto.AuthReqDTO;
 import com.example.scoi.domain.auth.dto.AuthResDTO;
 import com.example.scoi.domain.auth.service.AuthService;
+import com.example.scoi.domain.member.dto.MemberReqDTO;
+import com.example.scoi.domain.member.exception.code.MemberSuccessCode;
 import com.example.scoi.global.apiPayload.ApiResponse;
 import com.example.scoi.global.apiPayload.code.BaseSuccessCode;
 import com.example.scoi.global.apiPayload.code.GeneralSuccessCode;
@@ -31,6 +33,19 @@ public class AuthController {
     ){
         BaseSuccessCode code = GeneralSuccessCode.OK;
         return ApiResponse.onSuccess(code, authService.generateSmsToken(phoneNumber));
+    }
+
+    // 간편 비밀번호 재설정
+    @Operation(
+            summary = "간편 비밀번호 재설정 API By 김주헌",
+            description = "비밀번호 분실 또는 5회 실패 시 재설정을 합니다."
+    )
+    @PostMapping("/password/reset")
+    public ApiResponse<Void> resetPassword(
+            @RequestBody MemberReqDTO.ResetPassword dto
+    ){
+        BaseSuccessCode code = MemberSuccessCode.RESET_SIMPLE_PASSWORD;
+        return ApiResponse.onSuccess(code, authService.resetPassword(dto));
     }
 
     @Operation(summary = "SMS 발송 By 장명준", description = "휴대폰 번호로 인증번호를 발송합니다.")

--- a/src/main/java/com/example/scoi/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/scoi/domain/member/controller/MemberController.java
@@ -49,16 +49,6 @@ public class MemberController implements MemberControllerDocs{
         }
     }
 
-    // 간편 비밀번호 재설정
-    @PostMapping("/members/me/password/reset")
-    public ApiResponse<Void> resetPassword(
-            @RequestBody MemberReqDTO.ResetPassword dto,
-            @AuthenticationPrincipal CustomUserDetails user
-    ){
-        BaseSuccessCode code = MemberSuccessCode.RESET_SIMPLE_PASSWORD;
-        return ApiResponse.onSuccess(code, memberService.resetPassword(dto, user.getUsername()));
-    }
-
     // 거래소 목록 조회
     @GetMapping("/exchanges")
     public ApiResponse<List<MemberResDTO.ExchangeList>> getExchangeList(

--- a/src/main/java/com/example/scoi/domain/member/controller/MemberControllerDocs.java
+++ b/src/main/java/com/example/scoi/domain/member/controller/MemberControllerDocs.java
@@ -29,12 +29,6 @@ public interface MemberControllerDocs {
     ApiResponse<Map<String, String>> changePassword(@RequestBody MemberReqDTO.ChangePassword dto, @AuthenticationPrincipal CustomUserDetails user) throws GeneralSecurityException;
 
     @Operation(
-            summary = "간편 비밀번호 재설정 API By 김주헌",
-            description = "비밀번호 분실 또는 5회 실패 시 재설정을 합니다."
-    )
-    ApiResponse<Void> resetPassword(@RequestBody MemberReqDTO.ResetPassword dto, @AuthenticationPrincipal CustomUserDetails user);
-
-    @Operation(
             summary = "거래소 목록 조회 API By 김주헌",
             description = "지원 거래소 목록과, 사용자 기준으로 지원 거래소와 연동 상태를 조회합니다."
     )

--- a/src/main/java/com/example/scoi/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/scoi/domain/member/service/MemberService.java
@@ -115,48 +115,6 @@ public class MemberService {
         return Optional.empty();
     }
 
-    // 간편 비밀번호 재설정
-    @Transactional
-    public Void resetPassword(
-            MemberReqDTO.ResetPassword dto,
-            String phoneNumber
-    ) {
-
-        Member member = memberRepository.findByPhoneNumber(phoneNumber)
-                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
-
-        // 인증된 전화번호인지 확인
-        if (!redisUtil.exists(VERIFICATION_PREFIX+dto.verificationCode())){
-            throw new MemberException(MemberErrorCode.UNVERIFIED_PHONE_NUMBER);
-        }
-
-        // 새 간편 비밀번호 검증
-        String newPassword;
-        try {
-            newPassword = new String(hashUtil.decryptAES(dto.newPassword()));
-
-            // 6자리 숫자가 아닌 경우
-            if (!newPassword.matches(SIMPLE_PASSWORD_REGEX)) {
-                throw new IllegalArgumentException();
-            }
-        } catch (GeneralSecurityException e ) {
-            Map<String, String> binding = new HashMap<>();
-            binding.put("password", "간편 비밀번호 복호화에 실패했습니다.");
-            throw new MemberException(GeneralErrorCode.VALIDATION_FAILED, binding);
-        } catch (IllegalArgumentException e) {
-            Map<String, String> binding = new HashMap<>();
-            binding.put("password", "6자리 숫자만 입력 가능합니다.");
-            throw new MemberException(GeneralErrorCode.VALIDATION_FAILED, binding);
-        }
-
-        // 간편 비밀번호 변경
-        member.updateSimplePassword(passwordEncoder.encode(newPassword));
-
-        // 로그인 횟수 -> 0
-        member.resetLoginFailCount();
-        return null;
-    }
-
     // 거래소 목록 조회
     public List<MemberResDTO.ExchangeList> getExchangeList(
             String phoneNumber

--- a/src/main/java/com/example/scoi/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/scoi/global/config/SecurityConfig.java
@@ -32,11 +32,12 @@ public class SecurityConfig {
 
     // 인증 없이 접근 가능한 경로
     private static final String[] PUBLIC_ENDPOINTS = {
-            "/auth/sms/**",      // SMS 발송/검증
-            "/auth/signup",      // 회원가입
-            "/auth/login",       // 로그인
-            "/auth/reissue",     // 토큰 재발급
-            "/auth/sms-token",   // 임시
+            "/auth/sms/**",          // SMS 발송/검증
+            "/auth/signup",          // 회원가입
+            "/auth/login",           // 로그인
+            "/auth/reissue",         // 토큰 재발급
+            "/auth/password/reset",  // 간편 비밀번호 재설정
+            "/auth/sms-token",       // 임시
             "/swagger-ui/**",
             "/v3/api-docs/**",
             "/swagger-resources/**",


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Close #104 

## 📌 개요
- 간편 비밀번호 재설정 API 도메인 이동 (마이페이지 -> 인증)

## 🔁 변경 사항
- 간편 비밀번호 재설정 API 도메인 이동 (마이페이지 -> 인증)
- 간편 비밀번호 재설정 API Private API (JWT 요구) -> Public API
- SecurityConfig-Public Endpoints에 추가

## 📸 스크린샷

## 👀 기타 더 이야기해볼 점

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
