### PR TITLE
♻️ [Refactor] SMS 인증 무차별 대입 방어 추가

### DIFF
--- a/src/main/java/com/example/scoi/domain/auth/exception/code/AuthErrorCode.java
+++ b/src/main/java/com/example/scoi/domain/auth/exception/code/AuthErrorCode.java
@@ -25,6 +25,9 @@ public enum AuthErrorCode implements BaseErrorCode {
     SMS_COOLDOWN(HttpStatus.TOO_MANY_REQUESTS,
             "AUTH429_1",
             "잠시 후 다시 시도해주세요. (1분 후 재요청 가능)"),
+    VERIFICATION_ATTEMPTS_EXCEEDED(HttpStatus.TOO_MANY_REQUESTS,
+            "AUTH429_2",
+            "인증 시도 횟수를 초과했습니다. 인증번호를 다시 요청해주세요."),
 
     // 회원가입/로그인 관련
     ALREADY_REGISTERED_PHONE(HttpStatus.CONFLICT,

--- a/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
@@ -65,9 +65,11 @@ public class AuthService {
     private static final String BLACKLIST_PREFIX = "blacklist:";
     private static final String SMS_COOLDOWN_PREFIX = "sms:cooldown:";
     private static final String SMS_REQUIRED_PREFIX = "sms_required:";
+    private static final String SMS_VERIFY_FAIL_PREFIX = "sms:verify:fail:";
 
     // 상수
     private static final int SMS_CODE_LENGTH = 6;
+    private static final int MAX_VERIFY_ATTEMPTS = 5;
     private static final long SMS_EXPIRATION_MINUTES = 5;
     private static final long VERIFICATION_EXPIRATION_MINUTES = 10;
     private static final long REFRESH_TOKEN_SLIDING_DAYS = 14;  // 비활성 기준 만료
@@ -99,7 +101,7 @@ public class AuthService {
                 );
                 CoolSmsDTO.SendRequest smsRequest = new CoolSmsDTO.SendRequest(message);
                 coolSmsClient.sendMessage(smsRequest);
-                log.info("SMS 발송 성공: phoneNumber={}, code={}", request.phoneNumber(), verificationCode);
+                log.info("SMS 발송 성공: phoneNumber={}", request.phoneNumber());
             } catch (Exception e) {
                 log.error("SMS 발송 실패: {}", e.getMessage());
                 throw new AuthException(AuthErrorCode.SMS_SEND_FAILED);
@@ -120,19 +122,37 @@ public class AuthService {
     public AuthResDTO.SmsVerifyResponse verifySms(AuthReqDTO.SmsVerifyRequest request) {
         // 1. Redis 조회
         String redisKey = SMS_PREFIX + request.phoneNumber();
+        String failKey = SMS_VERIFY_FAIL_PREFIX + request.phoneNumber();
         String storedCode = redisUtil.get(redisKey);
 
         if (storedCode == null) {
             throw new AuthException(AuthErrorCode.VERIFICATION_CODE_EXPIRED);
         }
 
-        // 2. 검증
+        // 2. 검증 (불일치 시 실패 카운터 증가 → 한도 초과 시 코드 무효화)
         if (!storedCode.equals(request.verificationCode())) {
-            throw new AuthException(AuthErrorCode.INVALID_VERIFICATION_CODE);
+            long failCount = redisUtil.increment(failKey, SMS_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+
+            if (failCount >= MAX_VERIFY_ATTEMPTS) {
+                // 한도 초과: 코드와 카운터 삭제 → 새 코드 재요청 유도
+                redisUtil.delete(redisKey);
+                redisUtil.delete(failKey);
+                log.warn("SMS 인증 시도 횟수 초과: phoneNumber={}, failCount={}", request.phoneNumber(), failCount);
+                throw new AuthException(AuthErrorCode.VERIFICATION_ATTEMPTS_EXCEEDED);
+            }
+
+            long remainingAttempts = MAX_VERIFY_ATTEMPTS - failCount;
+            log.warn("SMS 인증번호 불일치: phoneNumber={}, failCount={}, remainingAttempts={}",
+                    request.phoneNumber(), failCount, remainingAttempts);
+            throw new AuthException(
+                    AuthErrorCode.INVALID_VERIFICATION_CODE,
+                    Map.of("remainingAttempts", String.valueOf(remainingAttempts))
+            );
         }
 
-        // 3. SMS 코드 삭제
+        // 3. SMS 코드 및 실패 카운터 삭제 (성공 시 초기화)
         redisUtil.delete(redisKey);
+        redisUtil.delete(failKey);
 
         // 4. Verification Token 발급
         String verificationToken = jwtUtil.createVerificationToken(request.phoneNumber());
@@ -151,7 +171,8 @@ public class AuthService {
     /**
      * Verification Token 검증 (범용)
      * SMS 인증 완료 후 발급된 토큰이 유효한지 검증합니다.
-     * 다른 도메인(회원가입, 비밀번호 찾기, 휴대폰 번호 변경 등)에서 재사용 가능합니다.
+     * 토큰은 소멸되지 않으며, TTL(10분) 동안 회원가입·로그인·비밀번호 재설정 등
+     * 여러 동작에서 반복 재사용 가능합니다. (매번 SMS 재인증을 요구하지 않기 위한 의도된 설계)
      *
      * @param verificationToken SMS 인증 완료 후 발급받은 토큰
      * @param phoneNumber 검증할 휴대폰 번호
@@ -179,7 +200,7 @@ public class AuthService {
     public Void resetPassword(
             AuthReqDTO.ResetPassword dto
     ) {
-        // Verification Token 검증 및 소멸 (SMS 인증 완료 확인)
+        // Verification Token 검증 (SMS 인증 완료 확인 / 토큰은 TTL 동안 재사용 가능)
         String phoneNumber = validateVerificationToken(dto.verificationToken(), dto.phoneNumber());
 
         // 사용자 가져오기

--- a/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
@@ -87,9 +87,10 @@ public class AuthService {
         // 1. 인증번호 생성 (6자리)
         String verificationCode = String.format("%06d", ThreadLocalRandom.current().nextInt(1000000));
 
-        // 2. Redis 저장
+        // 2. Redis 저장 (새 코드에는 새 시도 예산을 부여)
         String redisKey = SMS_PREFIX + request.phoneNumber();
         redisUtil.set(redisKey, verificationCode, SMS_EXPIRATION_MINUTES, TimeUnit.MINUTES);
+        redisUtil.delete(SMS_VERIFY_FAIL_PREFIX + request.phoneNumber());
 
         // 3. CoolSMS 발송
         if (smsEnabled) {

--- a/src/main/java/com/example/scoi/global/config/RedisConfig.java
+++ b/src/main/java/com/example/scoi/global/config/RedisConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.DefaultRedisScript;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -18,5 +20,24 @@ public class RedisConfig {
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
         redisTemplate.setHashValueSerializer(new StringRedisSerializer());
         return redisTemplate;
+    }
+
+    /**
+     * INCR과 TTL 설정을 한 번의 왕복으로 묶는 스크립트.
+     * 최초 생성(값이 1)일 때만 만료를 걸어 카운터 수명을 첫 증가 시점에 고정한다.
+     * ARGV[1]은 밀리초 단위 TTL.
+     */
+    @Bean
+    public RedisScript<Long> incrementWithTtlScript() {
+        DefaultRedisScript<Long> script = new DefaultRedisScript<>();
+        script.setScriptText("""
+                local count = redis.call('INCR', KEYS[1])
+                if count == 1 then
+                  redis.call('PEXPIRE', KEYS[1], ARGV[1])
+                end
+                return count
+                """);
+        script.setResultType(Long.class);
+        return script;
     }
 }

--- a/src/main/java/com/example/scoi/global/redis/RedisUtil.java
+++ b/src/main/java/com/example/scoi/global/redis/RedisUtil.java
@@ -3,9 +3,11 @@ package com.example.scoi.global.redis;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.script.RedisScript;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
+import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -19,6 +21,7 @@ import java.util.concurrent.TimeUnit;
 public class RedisUtil {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final RedisScript<Long> incrementWithTtlScript;
 
     /**
      * Redis에 데이터 저장 (TTL 포함)
@@ -54,17 +57,19 @@ public class RedisUtil {
     }
 
     /**
-     * Redis 값을 원자적으로 1 증가시킵니다.
+     * Redis 값을 1 증가시킵니다.
+     * 증가와 TTL 설정이 한 번의 스크립트로 실행되므로, 중간 실패로 TTL 없는 키가 남지 않습니다.
      * 최초 생성(값이 1) 시에만 TTL을 설정하여 카운터 수명을 고정합니다.
      * @return 증가 후의 값
      */
     public long increment(String key, long timeout, TimeUnit unit) {
         validateInput(key);
 
-        Long count = redisTemplate.opsForValue().increment(key);
-        if (count != null && count == 1L) {
-            redisTemplate.expire(key, timeout, unit);
-        }
+        Long count = redisTemplate.execute(
+                incrementWithTtlScript,
+                List.of(key),
+                String.valueOf(unit.toMillis(timeout))
+        );
         log.debug("Redis 증가: key={}, count={}", key, count);
         return count == null ? 0L : count;
     }

--- a/src/main/java/com/example/scoi/global/redis/RedisUtil.java
+++ b/src/main/java/com/example/scoi/global/redis/RedisUtil.java
@@ -54,6 +54,22 @@ public class RedisUtil {
     }
 
     /**
+     * Redis 값을 원자적으로 1 증가시킵니다.
+     * 최초 생성(값이 1) 시에만 TTL을 설정하여 카운터 수명을 고정합니다.
+     * @return 증가 후의 값
+     */
+    public long increment(String key, long timeout, TimeUnit unit) {
+        validateInput(key);
+
+        Long count = redisTemplate.opsForValue().increment(key);
+        if (count != null && count == 1L) {
+            redisTemplate.expire(key, timeout, unit);
+        }
+        log.debug("Redis 증가: key={}, count={}", key, count);
+        return count == null ? 0L : count;
+    }
+
+    /**
      * Redis에서 데이터 삭제
      */
     public void delete(String key) {

--- a/src/test/java/com/example/scoi/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/scoi/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,132 @@
+package com.example.scoi.domain.auth.service;
+
+import com.example.scoi.domain.auth.dto.AuthReqDTO;
+import com.example.scoi.domain.auth.dto.AuthResDTO;
+import com.example.scoi.domain.auth.exception.AuthException;
+import com.example.scoi.domain.auth.exception.code.AuthErrorCode;
+import com.example.scoi.domain.member.repository.MemberRepository;
+import com.example.scoi.global.redis.RedisUtil;
+import com.example.scoi.global.security.jwt.JwtUtil;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * {@link AuthService#verifySms} SMS 무차별 대입 방어 로직 단위 테스트.
+ * Spring 컨텍스트 없이 Mockito로 협력 객체를 스텁하여 분기별 동작을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock
+    private MemberRepository memberRepository;
+    @Mock
+    private JwtUtil jwtUtil;
+    @Mock
+    private RedisUtil redisUtil;
+
+    @InjectMocks
+    private AuthService authService;
+
+    private static final String PHONE = "01012345678";
+    private static final String CODE = "123456";
+    private static final String SMS_KEY = "sms:" + PHONE;
+    private static final String FAIL_KEY = "sms:verify:fail:" + PHONE;
+
+    private AuthReqDTO.SmsVerifyRequest request(String verificationCode) {
+        return new AuthReqDTO.SmsVerifyRequest(PHONE, verificationCode);
+    }
+
+    @Nested
+    @DisplayName("verifySms - SMS 인증번호 검증")
+    class VerifySms {
+
+        @Test
+        @DisplayName("성공: 코드 일치 시 토큰 발급 및 코드·실패카운터 삭제")
+        void success() {
+            // given
+            when(redisUtil.get(SMS_KEY)).thenReturn(CODE);
+            when(jwtUtil.createVerificationToken(PHONE)).thenReturn("verification-token");
+            when(memberRepository.existsByPhoneNumber(PHONE)).thenReturn(true);
+
+            // when
+            AuthResDTO.SmsVerifyResponse response = authService.verifySms(request(CODE));
+
+            // then
+            assertThat(response.verificationToken()).isEqualTo("verification-token");
+            assertThat(response.isExistingMember()).isTrue();
+            verify(redisUtil).delete(SMS_KEY);   // 코드 삭제
+            verify(redisUtil).delete(FAIL_KEY);  // 실패 카운터 초기화
+        }
+
+        @Test
+        @DisplayName("실패: 저장된 코드가 없으면 VERIFICATION_CODE_EXPIRED, 실패 카운터 증가 안 함")
+        void expired() {
+            // given
+            when(redisUtil.get(SMS_KEY)).thenReturn(null);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifySms(request(CODE)))
+                    .isInstanceOf(AuthException.class)
+                    .extracting(e -> ((AuthException) e).getCode())
+                    .isEqualTo(AuthErrorCode.VERIFICATION_CODE_EXPIRED);
+
+            verify(redisUtil, never()).increment(any(), anyLong(), any());
+        }
+
+        @Test
+        @DisplayName("실패: 코드 불일치 - 한도 미만이면 INVALID_VERIFICATION_CODE + 남은 횟수 반환")
+        void mismatchUnderLimit() {
+            // given: 실패 카운터가 2 (한도 5 미만)
+            when(redisUtil.get(SMS_KEY)).thenReturn(CODE);
+            when(redisUtil.increment(eq(FAIL_KEY), eq(5L), eq(TimeUnit.MINUTES))).thenReturn(2L);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifySms(request("000000")))
+                    .isInstanceOf(AuthException.class)
+                    .satisfies(e -> {
+                        AuthException ex = (AuthException) e;
+                        assertThat(ex.getCode()).isEqualTo(AuthErrorCode.INVALID_VERIFICATION_CODE);
+                        assertThat(ex.getBind()).containsEntry("remainingAttempts", "3"); // 5 - 2
+                    });
+
+            // 한도 미만이므로 코드·카운터 삭제하지 않음
+            verify(redisUtil, never()).delete(SMS_KEY);
+            verify(redisUtil, never()).delete(FAIL_KEY);
+        }
+
+        @Test
+        @DisplayName("실패: 코드 불일치 - 한도 도달 시 VERIFICATION_ATTEMPTS_EXCEEDED + 코드·카운터 삭제")
+        void mismatchLimitExceeded() {
+            // given: 실패 카운터가 5 (한도 도달)
+            when(redisUtil.get(SMS_KEY)).thenReturn(CODE);
+            when(redisUtil.increment(eq(FAIL_KEY), eq(5L), eq(TimeUnit.MINUTES))).thenReturn(5L);
+
+            // when & then
+            assertThatThrownBy(() -> authService.verifySms(request("000000")))
+                    .isInstanceOf(AuthException.class)
+                    .extracting(e -> ((AuthException) e).getCode())
+                    .isEqualTo(AuthErrorCode.VERIFICATION_ATTEMPTS_EXCEEDED);
+
+            // 코드 무효화: 코드·카운터 모두 삭제
+            verify(redisUtil).delete(SMS_KEY);
+            verify(redisUtil).delete(FAIL_KEY);
+        }
+    }
+}

--- a/src/test/java/com/example/scoi/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/example/scoi/domain/auth/service/AuthServiceTest.java
@@ -28,7 +28,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * {@link AuthService#verifySms} SMS 무차별 대입 방어 로직 단위 테스트.
+ * SMS 인증 무차별 대입 방어 로직 단위 테스트.
  * Spring 컨텍스트 없이 Mockito로 협력 객체를 스텁하여 분기별 동작을 검증한다.
  */
 @ExtendWith(MockitoExtension.class)
@@ -48,6 +48,7 @@ class AuthServiceTest {
     private static final String CODE = "123456";
     private static final String SMS_KEY = "sms:" + PHONE;
     private static final String FAIL_KEY = "sms:verify:fail:" + PHONE;
+    private static final String COOLDOWN_KEY = "sms:cooldown:" + PHONE;
 
     private AuthReqDTO.SmsVerifyRequest request(String verificationCode) {
         return new AuthReqDTO.SmsVerifyRequest(PHONE, verificationCode);
@@ -127,6 +128,40 @@ class AuthServiceTest {
             // 코드 무효화: 코드·카운터 모두 삭제
             verify(redisUtil).delete(SMS_KEY);
             verify(redisUtil).delete(FAIL_KEY);
+        }
+    }
+
+    @Nested
+    @DisplayName("sendSms - SMS 인증번호 발송")
+    class SendSms {
+
+        @Test
+        @DisplayName("새 코드 발급 시 이전 실패 카운터를 초기화한다")
+        void resetsFailCounter() {
+            // given: 쿨다운 없음 (smsEnabled 기본값 false → 실제 발송 건너뜀)
+            when(redisUtil.exists(COOLDOWN_KEY)).thenReturn(false);
+
+            // when
+            authService.sendSms(new AuthReqDTO.SmsSendRequest(PHONE));
+
+            // then: 새 코드에는 새 시도 예산이 주어져야 한다
+            verify(redisUtil).set(eq(SMS_KEY), any(), eq(5L), eq(TimeUnit.MINUTES));
+            verify(redisUtil).delete(FAIL_KEY);
+        }
+
+        @Test
+        @DisplayName("쿨다운 중이면 SMS_COOLDOWN, 실패 카운터를 건드리지 않는다")
+        void cooldown() {
+            // given
+            when(redisUtil.exists(COOLDOWN_KEY)).thenReturn(true);
+
+            // when & then
+            assertThatThrownBy(() -> authService.sendSms(new AuthReqDTO.SmsSendRequest(PHONE)))
+                    .isInstanceOf(AuthException.class)
+                    .extracting(e -> ((AuthException) e).getCode())
+                    .isEqualTo(AuthErrorCode.SMS_COOLDOWN);
+
+            verify(redisUtil, never()).delete(FAIL_KEY);
         }
     }
 }

--- a/src/test/java/com/example/scoi/global/redis/RedisUtilIntegrationTest.java
+++ b/src/test/java/com/example/scoi/global/redis/RedisUtilIntegrationTest.java
@@ -1,0 +1,98 @@
+package com.example.scoi.global.redis;
+
+import com.example.scoi.global.config.RedisConfig;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIf;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link RedisUtil#increment} 이 실제 Redis에서 INCR과 TTL 설정을 한 번의 스크립트로 수행하는지 검증한다.
+ * 단위 테스트는 RedisUtil을 모킹하므로 Lua 스크립트 자체는 여기서만 실증된다.
+ * Redis가 떠 있지 않으면 테스트 전체를 건너뛴다.
+ */
+@EnabledIf("redisAvailable")
+class RedisUtilIntegrationTest {
+
+    private static final String HOST = "localhost";
+    private static final int PORT = 6379;
+    private static final String KEY = "test:redisutil:increment";
+
+    private static LettuceConnectionFactory connectionFactory;
+    private static RedisTemplate<String, String> redisTemplate;
+    private static RedisUtil redisUtil;
+
+    static boolean redisAvailable() {
+        try (Socket socket = new Socket()) {
+            socket.connect(new InetSocketAddress(HOST, PORT), 500);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    @BeforeAll
+    static void setUp() {
+        connectionFactory = new LettuceConnectionFactory(HOST, PORT);
+        connectionFactory.afterPropertiesSet();
+
+        RedisConfig config = new RedisConfig();
+        redisTemplate = config.redisTemplate(connectionFactory);
+        redisTemplate.afterPropertiesSet();
+
+        redisUtil = new RedisUtil(redisTemplate, config.incrementWithTtlScript());
+    }
+
+    @AfterAll
+    static void tearDown() {
+        connectionFactory.destroy();
+    }
+
+    @AfterEach
+    void cleanUp() {
+        redisTemplate.delete(KEY);
+    }
+
+    @Test
+    @DisplayName("최초 증가: 1을 반환하고 TTL이 설정된다")
+    void firstIncrementSetsTtl() {
+        long count = redisUtil.increment(KEY, 5, TimeUnit.MINUTES);
+
+        assertThat(count).isEqualTo(1L);
+        assertThat(redisTemplate.getExpire(KEY, TimeUnit.SECONDS))
+                .isPositive()
+                .isLessThanOrEqualTo(300L);
+    }
+
+    @Test
+    @DisplayName("재증가: 값은 늘어나지만 TTL은 초기화되지 않는다 (고정 창)")
+    void subsequentIncrementDoesNotResetTtl() {
+        redisUtil.increment(KEY, 5, TimeUnit.MINUTES);
+        // 첫 증가가 건 TTL을 짧게 덮어써 두면, 재증가가 TTL을 다시 5분으로 늘리는지 확인할 수 있다
+        redisTemplate.expire(KEY, 30, TimeUnit.SECONDS);
+
+        long count = redisUtil.increment(KEY, 5, TimeUnit.MINUTES);
+
+        assertThat(count).isEqualTo(2L);
+        assertThat(redisTemplate.getExpire(KEY, TimeUnit.SECONDS)).isLessThanOrEqualTo(30L);
+    }
+
+    @Test
+    @DisplayName("저장된 값은 정수 문자열이라 get()으로 읽을 수 있다")
+    void valueIsReadableAsString() {
+        redisUtil.increment(KEY, 5, TimeUnit.MINUTES);
+        redisUtil.increment(KEY, 5, TimeUnit.MINUTES);
+
+        assertThat(redisUtil.get(KEY)).isEqualTo("2");
+    }
+}


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Closed #136 

## 📌 개요
- 인증 로직 점검 중 발견된 보안 이슈를 개선했습니다.
- SMS 인증번호(`/auth/sms/verify`)에 시도 횟수 제한이 없어, 5분 유효창 내에 6자리 코드(100만 조합)를 무차별 대입할 수 있었습니다. 실패 카운터를 추가해 이를 차단합니다.

## 🔁 변경 사항
- SMS 무차별 대입 방어
- 코드 불일치 5회 초과 시 해당 인증번호를 무효화 → 새 코드 재요청 유도(발송 60초 쿨다운으로 대입 차단) 
- 인증 성공 시 카운터 초기화, 불일치 시 남은 시도 횟수(`remainingAttempts`) 응답
- 로그 노출 제거: `sendSms` 발송 성공 로그에서 인증번호(`code`)를 제거했습니다. (운영 로그 유출 방지)
- 주석 정정: verification token은 TTL(10분) 동안 재사용 가능한 의도된 설계임을 명확히 했습니다. (동작 변경 없음)
- **테스트**: `verifySms` 분기 로직 단위 테스트 4종 추가 (성공 / 코드 만료 / 한도 미만 / 한도 초과)
## 📸 스크린샷

## 👀 기타 더 이야기해볼 점
- 실패 한도(5회)와 카운터 TTL(코드 수명 5분)은 기존 로그인 실패 잠금 정책과 통일했습니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * SMS 인증 실패 횟수 제한이 추가되어, 반복 실패 시 인증번호 재요청이 필요합니다.
  * 인증 성공 시 발급되는 검증 토큰의 사용 안내가 더 명확해졌습니다.

* **Bug Fixes**
  * 인증번호가 만료되었을 때 적절한 오류가 반환됩니다.
  * 인증 실패 시 남은 시도 횟수가 함께 안내됩니다.
  * 인증 성공 후에는 관련 인증 정보가 정상적으로 초기화됩니다.

* **Tests**
  * SMS 인증 성공/실패/만료/횟수 초과 흐름에 대한 검증이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->