### PR TITLE
♻️ refactor: Auth 도메인 디테일/일관성 보완 (#142)

### DIFF
--- a/src/main/java/com/example/scoi/domain/auth/dto/AuthResDTO.java
+++ b/src/main/java/com/example/scoi/domain/auth/dto/AuthResDTO.java
@@ -9,7 +9,7 @@ public class AuthResDTO {
     // SMS 발송 응답
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record SmsSendResponse(
-            LocalDateTime expiredAt,  // 인증번호 만료 시간 (발송 시간 + 3분)
+            LocalDateTime expiredAt,  // 인증번호 만료 시간 (발송 시간 + 5분)
             String verificationCode   // 개발/QA 환경에서만 포함 (프로덕션에서는 null)
     ) {}
 

--- a/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
+++ b/src/main/java/com/example/scoi/domain/auth/service/AuthService.java
@@ -197,7 +197,7 @@ public class AuthService {
     }
 
     // 간편 비밀번호 재설정
-    @jakarta.transaction.Transactional
+    @Transactional
     public Void resetPassword(
             AuthReqDTO.ResetPassword dto
     ) {
@@ -232,6 +232,9 @@ public class AuthService {
 
         // 로그인 횟수 -> 0
         member.resetLoginFailCount();
+
+        // RT 만료로 걸린 SMS 재인증 플래그 해제 (이미 SMS 인증을 통과했으므로 잠금 완전 해제)
+        redisUtil.delete(SMS_REQUIRED_PREFIX + phoneNumber);
         return null;
     }
 
@@ -481,19 +484,5 @@ public class AuthService {
         }
 
         log.info("로그아웃 성공: phoneNumber={}", phoneNumber);
-    }
-
-    // 임시
-    public String generateSmsToken(
-            String phoneNumber
-    ) {
-        // 4. Verification Token 발급
-        String verificationToken = jwtUtil.createVerificationToken(phoneNumber);
-
-        // 5. Redis 저장 (10분 TTL)
-        String tokenKey = VERIFICATION_PREFIX + verificationToken;
-        redisUtil.set(tokenKey, phoneNumber, VERIFICATION_EXPIRATION_MINUTES, TimeUnit.MINUTES);
-
-        return verificationToken;
     }
 }


### PR DESCRIPTION
## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## ❗️ 관련 이슈 링크
Closed #142 

## 📌 개요
- Auth 도메인 코드 검토 중 발견된 버그가 아닌 정합성/일관성/데드코드 4건을 정리했습니다.
- 보안 설계 변경(기기 바인딩)은 프론트 협의가 필요한 큰 작업이라 별도 `✨ [Feat]` 이슈로 분리했습니다.

## 🔁 변경 사항
- 주석 정정: `SmsSendResponse.expiredAt` 주석 `발송 시간 + 3분` → `+ 5분` (실제 값 `SMS_EXPIRATION_MINUTES = 5`와 불일치 정정)
- 데드코드 제거: `generateSmsToken` 메서드 삭제 (전 코드베이스 호출처 0건, SMS 인증 없이 verificationToken을 발급해 노출 시 인증 우회 소지)
- 트랜잭션 애노테이션 통일: `resetPassword`의 `@jakarta.transaction.Transactional` → 스프링 `@Transactional` (나머지 메서드와 일관성, 동작 변화 없음)
- 잠금 플래그 정리: `resetPassword`에서 실패 카운트 초기화와 함께 `sms_required:{phone}` Redis 플래그도 삭제 → SMS 인증을 이미 통과했으므로 RT 만료 잠금까지 일관되게 해제

## 📸 스크린샷
- 해당 없음 (백엔드 내부 로직/주석 정리)

## 👀 기타 더 이야기해볼 점
- 보류: "정상 로그인에 stale verificationToken이 섞이면 튕기는 엣지 케이스" → 프론트 토큰 재사용 흐름 확인 후 결정
- 별도 이슈: 기기 바인딩(신뢰 기기, 새 기기 로그인 시 SMS 강제)
- 잠금 플래그 정리(4번째 항목)는 Redis·SMS 통합 환경에서 수동 검증 필요: RT 만료 플래그 생성 → 비번 재설정 → 이후 SMS 없이 로그인 성공 확인

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비밀번호 재설정이 완료되면 불필요한 SMS 재인증 요구 상태가 자동으로 해제됩니다.
  * 비밀번호 재설정 처리의 안정성이 개선되었습니다.

* **문서**
  * SMS 인증번호 만료 시간이 발송 후 5분으로 안내되도록 기준을 수정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->